### PR TITLE
Fix Infinite Recursion In Implementation Of Fold In PersistentExecutor

### DIFF
--- a/zio-flow/shared/src/main/scala/zio/flow/server/PersistentExecutor.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/server/PersistentExecutor.scala
@@ -156,6 +156,12 @@ final case class PersistentExecutor(
               }
             }
 
+          case fold @ Fold(Input(), _, _) =>
+            ref.get.map { state =>
+              val env = state.currentEnvironment
+              state.copy(current = fold.ifSuccess(env.toRemote))
+            } *> step(ref)
+
           case fold @ Fold(_, _, _) =>
             ref.update { state =>
               val env         = state.currentEnvironment

--- a/zio-flow/shared/src/main/scala/zio/flow/server/PersistentExecutor.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/server/PersistentExecutor.scala
@@ -204,7 +204,6 @@ final case class PersistentExecutor(
 
           case Ensuring(flow, finalizer) =>
             ref.get.flatMap { state =>
-              val env  = state.currentEnvironment.schema
               val cont = Continuation(finalizer, ZFlow.input)
               ref.update(_.copy(current = flow, stack = cont :: state.stack)) *>
                 step(ref)


### PR DESCRIPTION
We need to special case the handling of `Fold(Input(), _, _)` in the run loop to remain productive since we use this pattern in the interpretation of `Fold` to convert a function to a flow.