### PR TITLE
Create extension methods on Remote[Either]

### DIFF
--- a/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
@@ -25,6 +25,12 @@ class RemoteEitherSyntax[A, B](val self: Remote[Either[A, B]]) {
 
   final def swap: Remote[Either[B, A]] = Remote.SwapEither(self)
 
+  final def joinRight[A1 >: A, B1 >: B, C](implicit ev: B1 <:< Either[A1, C]): Remote[Either[A1, C]] =
+    handleEither(
+      _ => self.asInstanceOf[Remote[Either[A1, C]]],
+      r => r.asInstanceOf[Remote[Either[A1, C]]]
+    )
+
   final def contains[B1 >: B](elem: Remote[B1]): Remote[Boolean] =
     handleEither(_ => Remote(false), Remote.Equal(_, elem))
 

--- a/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
@@ -25,7 +25,7 @@ class RemoteEitherSyntax[A, B](val self: Remote[Either[A, B]]) {
 
   def getOrElse(or: => Remote[B]): Remote[B] = ???
 
-  def toOption: Remote[Option[B]] = ???
+  def toOption: Remote[Option[B]] = handleEither(_ => Remote(None), Remote.Some0(_))
 
   def toTry(implicit ev: A <:< Throwable): Try[B] = ???
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
@@ -50,6 +50,8 @@ class RemoteEitherSyntax[A, B](val self: Remote[Either[A, B]]) {
         )
     )
 
+  final def toSeq: Remote[Seq[B]] = handleEither(_ => Remote(Nil), b => Remote.Cons(Remote(Nil), b))
+
   final def toOption: Remote[Option[B]] = handleEither(_ => Remote(None), Remote.Some0(_))
 
   def toTry(implicit ev: A <:< Throwable): Try[B] = ???

--- a/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
@@ -25,6 +25,8 @@ class RemoteEitherSyntax[A, B](val self: Remote[Either[A, B]]) {
 
   def forall(f: Remote[B] => Remote[Boolean]): Remote[Boolean] = handleEither(_ => Remote(true), f)
 
+  def exists(f: Remote[B] => Remote[Boolean]): Remote[Boolean] = handleEither(_ => Remote(false), f)
+
   def getOrElse(or: => Remote[B]): Remote[B] = handleEither(_ => or, identity(_))
 
   def toOption: Remote[Option[B]] = handleEither(_ => Remote(None), Remote.Some0(_))

--- a/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
@@ -21,17 +21,17 @@ class RemoteEitherSyntax[A, B](val self: Remote[Either[A, B]]) {
   final def isRight: Remote[Boolean] =
     handleEither(_ => Remote(false), _ => Remote(true))
 
-  def swap: Remote[Either[B, A]] = Remote.SwapEither(self)
+  final def swap: Remote[Either[B, A]] = Remote.SwapEither(self)
 
-  def forall(f: Remote[B] => Remote[Boolean]): Remote[Boolean] = handleEither(_ => Remote(true), f)
+  final def forall(f: Remote[B] => Remote[Boolean]): Remote[Boolean] = handleEither(_ => Remote(true), f)
 
-  def exists(f: Remote[B] => Remote[Boolean]): Remote[Boolean] = handleEither(_ => Remote(false), f)
+  final def exists(f: Remote[B] => Remote[Boolean]): Remote[Boolean] = handleEither(_ => Remote(false), f)
 
-  def getOrElse(or: => Remote[B]): Remote[B] = handleEither(_ => or, identity(_))
+  final def getOrElse(or: => Remote[B]): Remote[B] = handleEither(_ => or, identity(_))
 
-  def orElse[A1 >: A, B1 >: B](or: => Remote[Either[A1, B1]]): Remote[Either[A1, B1]] = handleEither(_ => or, _ => self)
+  final def orElse[A1 >: A, B1 >: B](or: => Remote[Either[A1, B1]]): Remote[Either[A1, B1]] = handleEither(_ => or, _ => self)
 
-  def toOption: Remote[Option[B]] = handleEither(_ => Remote(None), Remote.Some0(_))
+  final def toOption: Remote[Option[B]] = handleEither(_ => Remote(None), Remote.Some0(_))
 
   def toTry(implicit ev: A <:< Throwable): Try[B] = ???
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
@@ -23,6 +23,8 @@ class RemoteEitherSyntax[A, B](val self: Remote[Either[A, B]]) {
 
   def swap: Remote[Either[B, A]] = Remote.SwapEither(self)
 
+  def forall(f: Remote[B] => Remote[Boolean]): Remote[Boolean] = handleEither(_ => Remote(true), f)
+
   def getOrElse(or: => Remote[B]): Remote[B] = handleEither(_ => or, identity(_))
 
   def toOption: Remote[Option[B]] = handleEither(_ => Remote(None), Remote.Some0(_))

--- a/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
@@ -23,13 +23,17 @@ class RemoteEitherSyntax[A, B](val self: Remote[Either[A, B]]) {
 
   final def swap: Remote[Either[B, A]] = Remote.SwapEither(self)
 
+  final def contains[B1 >: B](elem: Remote[B1]): Remote[Boolean] =
+    handleEither(_ => Remote(false), Remote.Equal(_, elem))
+
   final def forall(f: Remote[B] => Remote[Boolean]): Remote[Boolean] = handleEither(_ => Remote(true), f)
 
   final def exists(f: Remote[B] => Remote[Boolean]): Remote[Boolean] = handleEither(_ => Remote(false), f)
 
   final def getOrElse(or: => Remote[B]): Remote[B] = handleEither(_ => or, identity(_))
 
-  final def orElse[A1 >: A, B1 >: B](or: => Remote[Either[A1, B1]]): Remote[Either[A1, B1]] = handleEither(_ => or, _ => self)
+  final def orElse[A1 >: A, B1 >: B](or: => Remote[Either[A1, B1]]): Remote[Either[A1, B1]] =
+    handleEither(_ => or, _ => self)
 
   final def toOption: Remote[Option[B]] = handleEither(_ => Remote(None), Remote.Some0(_))
 

--- a/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
@@ -31,6 +31,12 @@ class RemoteEitherSyntax[A, B](val self: Remote[Either[A, B]]) {
       r => r.asInstanceOf[Remote[Either[A1, C]]]
     )
 
+  final def joinLeft[A1 >: A, B1 >: B, C](implicit ev: A1 <:< Either[C, B1]): Remote[Either[C, B1]] =
+    handleEither(
+      l => l.asInstanceOf[Remote[Either[C, B1]]],
+      _ => self.asInstanceOf[Remote[Either[C, B1]]]
+    )
+
   final def contains[B1 >: B](elem: Remote[B1]): Remote[Boolean] =
     handleEither(_ => Remote(false), Remote.Equal(_, elem))
 

--- a/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
@@ -29,6 +29,8 @@ class RemoteEitherSyntax[A, B](val self: Remote[Either[A, B]]) {
 
   def getOrElse(or: => Remote[B]): Remote[B] = handleEither(_ => or, identity(_))
 
+  def orElse[A1 >: A, B1 >: B](or: => Remote[Either[A1, B1]]): Remote[Either[A1, B1]] = handleEither(_ => or, _ => self)
+
   def toOption: Remote[Option[B]] = handleEither(_ => Remote(None), Remote.Some0(_))
 
   def toTry(implicit ev: A <:< Throwable): Try[B] = ???

--- a/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
@@ -23,7 +23,7 @@ class RemoteEitherSyntax[A, B](val self: Remote[Either[A, B]]) {
 
   def swap: Remote[Either[B, A]] = Remote.SwapEither(self)
 
-  def getOrElse(or: => Remote[B]): Remote[B] = ???
+  def getOrElse(or: => Remote[B]): Remote[B] = handleEither(_ => or, identity(_))
 
   def toOption: Remote[Option[B]] = handleEither(_ => Remote(None), Remote.Some0(_))
 

--- a/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/RemoteEitherSyntax.scala
@@ -21,7 +21,7 @@ class RemoteEitherSyntax[A, B](val self: Remote[Either[A, B]]) {
   final def isRight: Remote[Boolean] =
     handleEither(_ => Remote(false), _ => Remote(true))
 
-  def swap: Remote[Either[B, A]] = ???
+  def swap: Remote[Either[B, A]] = Remote.SwapEither(self)
 
   def getOrElse(or: => Remote[B]): Remote[B] = ???
 

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
@@ -32,6 +32,11 @@ object RemoteEitherSpec extends DefaultRunnableSpec {
       check(Gen.either(Gen.anyInt, Gen.boolean)) { either =>
         Remote(either).swap <-> either.swap
       }
+    },
+    testM("toOption") {
+      check(Gen.either(Gen.boolean, Gen.anyInt)) { either =>
+        Remote(either).toOption <-> either.toOption
+      }
     }
   )
 }

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
@@ -54,6 +54,11 @@ object RemoteEitherSpec extends DefaultRunnableSpec {
         Remote(either).joinRight <-> either.joinRight
       }
     },
+    testM("joinLeft") {
+      check(Gen.either(Gen.either(Gen.anyInt, Gen.anyLong), Gen.anyLong)) { either =>
+        Remote(either).joinLeft <-> either.joinLeft
+      }
+    },
     testM("contains") {
       check(Gen.either(Gen.boolean, Gen.anyInt), Gen.anyInt) { (either, int) =>
         Remote(either).contains(Remote(int)) <-> either.contains(int)

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
@@ -34,6 +34,11 @@ object RemoteEitherSpec extends DefaultRunnableSpec {
         Remote(either).getOrElse(int) <-> either.getOrElse(int)
       }
     },
+    testM("orElse") {
+      check(Gen.either(Gen.boolean, Gen.anyInt), Gen.either(Gen.boolean, Gen.anyLong)) { (eitherInt, eitherLong) =>
+        Remote(eitherInt).orElse(eitherLong) <-> eitherInt.orElse(eitherLong)
+      }
+    },
     testM("swap") {
       check(Gen.either(Gen.anyInt, Gen.boolean)) { either =>
         Remote(either).swap <-> either.swap

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
@@ -49,6 +49,11 @@ object RemoteEitherSpec extends DefaultRunnableSpec {
         Remote(either).swap <-> either.swap
       }
     },
+    testM("joinRight") {
+      check(Gen.either(Gen.anyInt, Gen.either(Gen.anyInt, Gen.anyLong))) { either =>
+        Remote(either).joinRight <-> either.joinRight
+      }
+    },
     testM("contains") {
       check(Gen.either(Gen.boolean, Gen.anyInt), Gen.anyInt) { (either, int) =>
         Remote(either).contains(Remote(int)) <-> either.contains(int)

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
@@ -64,6 +64,11 @@ object RemoteEitherSpec extends DefaultRunnableSpec {
         Remote(either).exists(partialLift(f)) <-> either.exists(f)
       }
     },
+    testM("toSeq") {
+      check(Gen.either(Gen.boolean, Gen.anyInt)) { either =>
+        Remote(either).toSeq <-> either.toSeq
+      }
+    },
     testM("toOption") {
       check(Gen.either(Gen.boolean, Gen.anyInt)) { either =>
         Remote(either).toOption <-> either.toOption

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
@@ -9,7 +9,7 @@ object RemoteEitherSpec extends DefaultRunnableSpec {
     testM("handleEither") {
       check(Gen.either(Gen.anyInt, Gen.boolean)) { either =>
         val expected = either.fold(_ * 2, if (_) 10 else 20)
-        val result   = Remote(either).handleEither(_ * 2, _.ifThenElse(10, 20))
+        val result = Remote(either).handleEither(_ * 2, _.ifThenElse(10, 20))
         result <-> expected
       }
     },
@@ -27,6 +27,11 @@ object RemoteEitherSpec extends DefaultRunnableSpec {
       check(Gen.either(Gen.anyInt, Gen.boolean)) { either =>
         Remote(either).isLeft <-> either.isLeft
       }
+    },
+    testM("swap") {
+      check(Gen.either(Gen.anyInt, Gen.boolean)) { either =>
+        Remote(either).swap <-> either.swap
+      }
     }
-  ) @@ TestAspect.ignore
+  )
 }

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
@@ -44,6 +44,11 @@ object RemoteEitherSpec extends DefaultRunnableSpec {
         Remote(either).swap <-> either.swap
       }
     },
+    testM("contains") {
+      check(Gen.either(Gen.boolean, Gen.anyInt), Gen.anyInt) { (either, int) =>
+        Remote(either).contains(Remote(int)) <-> either.contains(int)
+      }
+    },
     testM("forall") {
       check(Gen.either(Gen.anyInt, Gen.anyInt), Gen.function(Gen.boolean)) { (either, f) =>
         Remote(either).forall(partialLift(f)) <-> either.forall(f)

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
@@ -28,6 +28,11 @@ object RemoteEitherSpec extends DefaultRunnableSpec {
         Remote(either).isLeft <-> either.isLeft
       }
     },
+    testM("getOrElse") {
+      check(Gen.either(Gen.boolean, Gen.anyInt), Gen.anyInt) { (either, int) =>
+        Remote(either).getOrElse(int) <-> either.getOrElse(int)
+      }
+    },
     testM("swap") {
       check(Gen.either(Gen.anyInt, Gen.boolean)) { either =>
         Remote(either).swap <-> either.swap

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
@@ -14,6 +14,21 @@ object RemoteEitherSpec extends DefaultRunnableSpec {
         result <-> expected
       }
     },
+    testM("flatMap") {
+      check(Gen.either(Gen.anyInt, Gen.anyInt), Gen.function(Gen.either(Gen.anyInt, Gen.anyLong))) { (either, f) =>
+        Remote(either).flatMap(partialLift(f)) <-> either.flatMap(f)
+      }
+    },
+    testM("map") {
+      check(Gen.either(Gen.anyInt, Gen.anyInt), Gen.function(Gen.anyLong)) { (either, f) =>
+        Remote(either).map(partialLift(f)) <-> either.map(f)
+      }
+    },
+    testM("flatten") {
+      check(Gen.either(Gen.anyInt, Gen.either(Gen.anyInt, Gen.anyLong))) { either =>
+        Remote(either).flatten <-> either.flatten
+      }
+    },
     testM("merge") {
       check(Gen.either(Gen.anyInt, Gen.anyInt)) { either =>
         Remote(either).merge <-> either.fold(identity, identity)

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
@@ -78,7 +78,7 @@ object RemoteEitherSpec extends DefaultRunnableSpec {
       test("return the first left result") {
         RemoteEitherSyntax.collectAll(Remote(List(Right(2), Left("V"), Right(9), Right(0), Left("P")))) <-> Left("V")
       }
-    ) @@ TestAspect.ignore
+    )
   )
 
   private def partialLift[A, B: Schema](f: A => B): Remote[A] => Remote[B] = a =>

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteEitherSpec.scala
@@ -44,6 +44,11 @@ object RemoteEitherSpec extends DefaultRunnableSpec {
         Remote(either).forall(partialLift(f)) <-> either.forall(f)
       }
     },
+    testM("exists") {
+      check(Gen.either(Gen.anyInt, Gen.anyInt), Gen.function(Gen.boolean)) { (either, f) =>
+        Remote(either).exists(partialLift(f)) <-> either.exists(f)
+      }
+    },
     testM("toOption") {
       check(Gen.either(Gen.boolean, Gen.anyInt)) { either =>
         Remote(either).toOption <-> either.toOption


### PR DESCRIPTION
Adds the `swap`, `toOption` and `getOrElse` extension methods to `Remote[Either`.

See #79 