### PR TITLE
Create extension methods on Remote[Numeric] 

### DIFF
--- a/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
@@ -168,6 +168,12 @@ object Remote {
       Remote.binaryEvalWithSchema(left, right)(numeric.min, MinNumeric(_, _, numeric), numeric.schema)
   }
 
+  final case class MaxNumeric[A](left: Remote[A], right: Remote[A], numeric: Numeric[A]) extends Remote[A] {
+
+    override def evalWithSchema: Either[Remote[A], SchemaAndValue[A]] =
+      Remote.binaryEvalWithSchema(left, right)(numeric.max, MaxNumeric(_, _, numeric), numeric.schema)
+  }
+
   final case class SinFractional[A](value: Remote[A], fractional: Fractional[A]) extends Remote[A] {
 
     override def evalWithSchema: Either[Remote[A], SchemaAndValue[A]] =

--- a/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
@@ -156,6 +156,12 @@ object Remote {
       Remote.binaryEvalWithSchema(left, right)(NumericInt.mod, ModNumeric(_, _), Schema.primitive[Int])
   }
 
+  final case class AbsoluteNumeric[A](value: Remote[A], numeric: Numeric[A]) extends Remote[A] {
+
+    override def evalWithSchema: Either[Remote[A], SchemaAndValue[A]] =
+      Remote.unaryEvalWithSchema(value)(numeric.abs, AbsoluteNumeric(_, numeric), numeric.schema)
+  }
+
   final case class SinFractional[A](value: Remote[A], fractional: Fractional[A]) extends Remote[A] {
 
     override def evalWithSchema: Either[Remote[A], SchemaAndValue[A]] =

--- a/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
@@ -186,6 +186,12 @@ object Remote {
       Remote.unaryEvalWithSchema(value)(numeric.ceil, CeilNumeric(_, numeric), numeric.schema)
   }
 
+  final case class RoundNumeric[A](value: Remote[A], numeric: Numeric[A]) extends Remote[A] {
+
+    override def evalWithSchema: Either[Remote[A], SchemaAndValue[A]] =
+      Remote.unaryEvalWithSchema(value)(numeric.round, RoundNumeric(_, numeric), numeric.schema)
+  }
+
   final case class SinFractional[A](value: Remote[A], fractional: Fractional[A]) extends Remote[A] {
 
     override def evalWithSchema: Either[Remote[A], SchemaAndValue[A]] =

--- a/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
@@ -162,6 +162,12 @@ object Remote {
       Remote.unaryEvalWithSchema(value)(numeric.abs, AbsoluteNumeric(_, numeric), numeric.schema)
   }
 
+  final case class MinNumeric[A](left: Remote[A], right: Remote[A], numeric: Numeric[A]) extends Remote[A] {
+
+    override def evalWithSchema: Either[Remote[A], SchemaAndValue[A]] =
+      Remote.binaryEvalWithSchema(left, right)(numeric.min, MinNumeric(_, _, numeric), numeric.schema)
+  }
+
   final case class SinFractional[A](value: Remote[A], fractional: Fractional[A]) extends Remote[A] {
 
     override def evalWithSchema: Either[Remote[A], SchemaAndValue[A]] =

--- a/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
@@ -174,6 +174,12 @@ object Remote {
       Remote.binaryEvalWithSchema(left, right)(numeric.max, MaxNumeric(_, _, numeric), numeric.schema)
   }
 
+  final case class FloorNumeric[A](value: Remote[A], numeric: Numeric[A]) extends Remote[A] {
+
+    override def evalWithSchema: Either[Remote[A], SchemaAndValue[A]] =
+      Remote.unaryEvalWithSchema(value)(numeric.floor, FloorNumeric(_, numeric), numeric.schema)
+  }
+
   final case class SinFractional[A](value: Remote[A], fractional: Fractional[A]) extends Remote[A] {
 
     override def evalWithSchema: Either[Remote[A], SchemaAndValue[A]] =

--- a/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
@@ -180,6 +180,12 @@ object Remote {
       Remote.unaryEvalWithSchema(value)(numeric.floor, FloorNumeric(_, numeric), numeric.schema)
   }
 
+  final case class CeilNumeric[A](value: Remote[A], numeric: Numeric[A]) extends Remote[A] {
+
+    override def evalWithSchema: Either[Remote[A], SchemaAndValue[A]] =
+      Remote.unaryEvalWithSchema(value)(numeric.ceil, CeilNumeric(_, numeric), numeric.schema)
+  }
+
   final case class SinFractional[A](value: Remote[A], fractional: Fractional[A]) extends Remote[A] {
 
     override def evalWithSchema: Either[Remote[A], SchemaAndValue[A]] =

--- a/zio-flow/shared/src/main/scala/zio/flow/RemoteNumericSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/RemoteNumericSyntax.scala
@@ -40,4 +40,7 @@ class RemoteNumericSyntax[A](self: Remote[A]) {
 
   final def floor(implicit numeric: Numeric[A]): Remote[A] =
     Remote.FloorNumeric(self.widen[A], numeric)
+
+  final def ceil(implicit numeric: Numeric[A]): Remote[A] =
+    Remote.CeilNumeric(self.widen[A], numeric)
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/RemoteNumericSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/RemoteNumericSyntax.scala
@@ -37,4 +37,7 @@ class RemoteNumericSyntax[A](self: Remote[A]) {
 
   final def max(that: Remote[A])(implicit numeric: Numeric[A]): Remote[A] =
     Remote.MaxNumeric(self.widen[A], that, numeric)
+
+  final def floor(implicit numeric: Numeric[A]): Remote[A] =
+    Remote.FloorNumeric(self.widen[A], numeric)
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/RemoteNumericSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/RemoteNumericSyntax.scala
@@ -31,4 +31,7 @@ class RemoteNumericSyntax[A](self: Remote[A]) {
 
   final def abs(implicit numeric: Numeric[A]): Remote[A] =
     Remote.AbsoluteNumeric(self.widen[A], numeric)
+
+  final def min(that: Remote[A])(implicit numeric: Numeric[A]): Remote[A] =
+    Remote.MinNumeric(self.widen[A], that, numeric)
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/RemoteNumericSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/RemoteNumericSyntax.scala
@@ -34,4 +34,7 @@ class RemoteNumericSyntax[A](self: Remote[A]) {
 
   final def min(that: Remote[A])(implicit numeric: Numeric[A]): Remote[A] =
     Remote.MinNumeric(self.widen[A], that, numeric)
+
+  final def max(that: Remote[A])(implicit numeric: Numeric[A]): Remote[A] =
+    Remote.MaxNumeric(self.widen[A], that, numeric)
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/RemoteNumericSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/RemoteNumericSyntax.scala
@@ -28,4 +28,7 @@ class RemoteNumericSyntax[A](self: Remote[A]) {
 
   final def mod(that: Remote[Int])(implicit ev: A <:< Int, numericInt: Numeric[Int]): Remote[Int] =
     Remote.ModNumeric(self.widen[Int], that)
+
+  final def abs(implicit numeric: Numeric[A]): Remote[A] =
+    Remote.AbsoluteNumeric(self.widen[A], numeric)
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/RemoteNumericSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/RemoteNumericSyntax.scala
@@ -43,4 +43,7 @@ class RemoteNumericSyntax[A](self: Remote[A]) {
 
   final def ceil(implicit numeric: Numeric[A]): Remote[A] =
     Remote.CeilNumeric(self.widen[A], numeric)
+
+  final def round(implicit numeric: Numeric[A]): Remote[A] =
+    Remote.RoundNumeric(self.widen[A], numeric)
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/numerics.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/numerics.scala
@@ -29,6 +29,8 @@ sealed trait Numeric[A] {
 
   def floor(left: A): A
 
+  def ceil(left: A): A
+
 }
 
 object Numeric extends NumericImplicits0 {
@@ -59,7 +61,9 @@ object Numeric extends NumericImplicits0 {
 
     override def max(left: Int, right: Int): Int = Math.max(left, right)
 
-    override def floor(left: Int): Int = Math.floor(left.toDouble).toInt
+    override def floor(left: Int): Int = Math.floor(left).toInt
+
+    override def ceil(left: Int): Int = Math.ceil(left).toInt
   }
 }
 
@@ -90,7 +94,9 @@ sealed trait NumericImplicits0 {
 
     override def max(left: Short, right: Short): Short = Math.max(left, right).toShort
 
-    override def floor(left: Short): Short = Math.floor(left.toDouble).toShort
+    override def floor(left: Short): Short = Math.floor(left).toShort
+
+    override def ceil(left: Short): Short = Math.ceil(left).toShort
   }
 
   implicit case object NumericLong extends Numeric[Long] {
@@ -118,7 +124,9 @@ sealed trait NumericImplicits0 {
 
     override def max(left: Long, right: Long): Long = Math.max(left, right)
 
-    override def floor(left: Long): Long = Math.floor(left.toDouble).toLong
+    override def floor(left: Long): Long = Math.floor(left).toLong
+
+    override def ceil(left: Long): Long = Math.ceil(left).toLong
   }
 
   implicit case object NumericBigInt extends Numeric[BigInt] {
@@ -151,6 +159,8 @@ sealed trait NumericImplicits0 {
     override def max(left: BigInt, right: BigInt): BigInt = Math.max(left.toInt, right.toInt)
 
     override def floor(left: BigInt): BigInt = Math.floor(left.doubleValue).toInt
+
+    override def ceil(left: BigInt): BigInt = Math.ceil(left.doubleValue).toInt
   }
 
   implicit case object NumericFloat extends Numeric[Float] {
@@ -179,6 +189,8 @@ sealed trait NumericImplicits0 {
     override def max(left: Float, right: Float): Float = Math.max(left, right)
 
     override def floor(left: Float): Float = Math.floor(left.toDouble).toFloat
+
+    override def ceil(left: Float): Float = Math.ceil(left).toFloat
   }
 
   implicit case object NumericDouble extends Numeric[Double] {
@@ -207,6 +219,8 @@ sealed trait NumericImplicits0 {
     override def max(left: Double, right: Double): Double = Math.max(left, right)
 
     override def floor(left: Double): Double = Math.floor(left)
+
+    override def ceil(left: Double): Double = Math.ceil(left)
   }
 
   implicit case object NumericBigDecimal extends Numeric[BigDecimal] {
@@ -239,6 +253,8 @@ sealed trait NumericImplicits0 {
     override def max(left: BigDecimal, right: BigDecimal): BigDecimal = Math.max(left.doubleValue, right.doubleValue)
 
     override def floor(left: BigDecimal): BigDecimal = Math.floor(left.doubleValue)
+
+    override def ceil(left: BigDecimal): BigDecimal = Math.ceil(left.doubleValue)
   }
 }
 
@@ -285,6 +301,8 @@ object Fractional {
     override def max(left: Float, right: Float): Float = Math.max(left, right)
 
     override def floor(left: Float): Float = Math.floor(left.toDouble).toFloat
+
+    override def ceil(left: Float): Float = Math.ceil(left).toFloat
   }
 
   implicit case object FractionalDouble extends Fractional[Double] {
@@ -318,6 +336,8 @@ object Fractional {
     override def max(left: Double, right: Double): Double = Math.max(left, right)
 
     override def floor(left: Double): Double = Math.floor(left)
+
+    override def ceil(left: Double): Double = Math.ceil(left)
   }
 
   implicit case object FractionalBigDecimal extends Fractional[BigDecimal] {
@@ -353,5 +373,7 @@ object Fractional {
     override def max(left: BigDecimal, right: BigDecimal): BigDecimal = Math.max(left.doubleValue, right.doubleValue)
 
     override def floor(left: BigDecimal): BigDecimal = Math.floor(left.doubleValue)
+
+    override def ceil(left: BigDecimal): BigDecimal = Math.ceil(left.doubleValue)
   }
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/numerics.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/numerics.scala
@@ -63,11 +63,11 @@ object Numeric extends NumericImplicits0 {
 
     override def max(left: Int, right: Int): Int = Math.max(left, right)
 
-    override def floor(left: Int): Int = Math.floor(left).toInt
+    override def floor(left: Int): Int = Math.floor(left.toDouble).toInt
 
-    override def ceil(left: Int): Int = Math.ceil(left).toInt
+    override def ceil(left: Int): Int = Math.ceil(left.toDouble).toInt
 
-    override def round(left: Int): Int = Math.round(left)
+    override def round(left: Int): Int = Math.round(left.toFloat)
   }
 }
 
@@ -92,17 +92,17 @@ sealed trait NumericImplicits0 {
 
     def schema: Schema[Short] = implicitly[Schema[Short]]
 
-    override def abs(left: Short): Short = Math.abs(left).toShort
+    override def abs(left: Short): Short = Math.abs(left.toDouble).toShort
 
-    override def min(left: Short, right: Short): Short = Math.min(left, right).toShort
+    override def min(left: Short, right: Short): Short = Math.min(left.toDouble, right.toDouble).toShort
 
-    override def max(left: Short, right: Short): Short = Math.max(left, right).toShort
+    override def max(left: Short, right: Short): Short = Math.max(left.toDouble, right.toDouble).toShort
 
-    override def floor(left: Short): Short = Math.floor(left).toShort
+    override def floor(left: Short): Short = Math.floor(left.toDouble).toShort
 
-    override def ceil(left: Short): Short = Math.ceil(left).toShort
+    override def ceil(left: Short): Short = Math.ceil(left.toDouble).toShort
 
-    override def round(left: Short): Short = Math.round(left).toShort
+    override def round(left: Short): Short = Math.round(left.toDouble).toShort
   }
 
   implicit case object NumericLong extends Numeric[Long] {
@@ -130,11 +130,11 @@ sealed trait NumericImplicits0 {
 
     override def max(left: Long, right: Long): Long = Math.max(left, right)
 
-    override def floor(left: Long): Long = Math.floor(left).toLong
+    override def floor(left: Long): Long = Math.floor(left.toDouble).toLong
 
-    override def ceil(left: Long): Long = Math.ceil(left).toLong
+    override def ceil(left: Long): Long = Math.ceil(left.toDouble).toLong
 
-    override def round(left: Long): Long = Math.round(left)
+    override def round(left: Long): Long = Math.round(left.toDouble)
   }
 
   implicit case object NumericBigInt extends Numeric[BigInt] {
@@ -200,9 +200,9 @@ sealed trait NumericImplicits0 {
 
     override def floor(left: Float): Float = Math.floor(left.toDouble).toFloat
 
-    override def ceil(left: Float): Float = Math.ceil(left).toFloat
+    override def ceil(left: Float): Float = Math.ceil(left.toDouble).toFloat
 
-    override def round(left: Float): Float = Math.round(left)
+    override def round(left: Float): Float = Math.round(left).toFloat
   }
 
   implicit case object NumericDouble extends Numeric[Double] {
@@ -234,7 +234,7 @@ sealed trait NumericImplicits0 {
 
     override def ceil(left: Double): Double = Math.ceil(left)
 
-    override def round(left: Double): Double = Math.round(left)
+    override def round(left: Double): Double = Math.round(left).toDouble
   }
 
   implicit case object NumericBigDecimal extends Numeric[BigDecimal] {
@@ -320,9 +320,9 @@ object Fractional {
 
     override def floor(left: Float): Float = Math.floor(left.toDouble).toFloat
 
-    override def ceil(left: Float): Float = Math.ceil(left).toFloat
+    override def ceil(left: Float): Float = Math.ceil(left.toDouble).toFloat
 
-    override def round(left: Float): Float = Math.round(left)
+    override def round(left: Float): Float = Math.round(left).toFloat
 
     override def inverseSin(a: Float): Float = Math.asin(a.toDouble).toFloat
 
@@ -364,7 +364,7 @@ object Fractional {
 
     override def ceil(left: Double): Double = Math.ceil(left)
 
-    override def round(left: Double): Double = Math.round(left)
+    override def round(left: Double): Double = Math.round(left).toDouble
 
     override def inverseSin(a: Double): Double = Math.asin(a)
 

--- a/zio-flow/shared/src/main/scala/zio/flow/numerics.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/numerics.scala
@@ -31,6 +31,8 @@ sealed trait Numeric[A] {
 
   def ceil(left: A): A
 
+  def round(left: A): A
+
 }
 
 object Numeric extends NumericImplicits0 {
@@ -64,6 +66,8 @@ object Numeric extends NumericImplicits0 {
     override def floor(left: Int): Int = Math.floor(left).toInt
 
     override def ceil(left: Int): Int = Math.ceil(left).toInt
+
+    override def round(left: Int): Int = Math.round(left)
   }
 }
 
@@ -97,6 +101,8 @@ sealed trait NumericImplicits0 {
     override def floor(left: Short): Short = Math.floor(left).toShort
 
     override def ceil(left: Short): Short = Math.ceil(left).toShort
+
+    override def round(left: Short): Short = Math.round(left).toShort
   }
 
   implicit case object NumericLong extends Numeric[Long] {
@@ -127,6 +133,8 @@ sealed trait NumericImplicits0 {
     override def floor(left: Long): Long = Math.floor(left).toLong
 
     override def ceil(left: Long): Long = Math.ceil(left).toLong
+
+    override def round(left: Long): Long = Math.round(left)
   }
 
   implicit case object NumericBigInt extends Numeric[BigInt] {
@@ -161,6 +169,8 @@ sealed trait NumericImplicits0 {
     override def floor(left: BigInt): BigInt = Math.floor(left.doubleValue).toInt
 
     override def ceil(left: BigInt): BigInt = Math.ceil(left.doubleValue).toInt
+
+    override def round(left: BigInt): BigInt = Math.round(left.doubleValue)
   }
 
   implicit case object NumericFloat extends Numeric[Float] {
@@ -191,6 +201,8 @@ sealed trait NumericImplicits0 {
     override def floor(left: Float): Float = Math.floor(left.toDouble).toFloat
 
     override def ceil(left: Float): Float = Math.ceil(left).toFloat
+
+    override def round(left: Float): Float = Math.round(left)
   }
 
   implicit case object NumericDouble extends Numeric[Double] {
@@ -221,6 +233,8 @@ sealed trait NumericImplicits0 {
     override def floor(left: Double): Double = Math.floor(left)
 
     override def ceil(left: Double): Double = Math.ceil(left)
+
+    override def round(left: Double): Double = Math.round(left)
   }
 
   implicit case object NumericBigDecimal extends Numeric[BigDecimal] {
@@ -255,6 +269,8 @@ sealed trait NumericImplicits0 {
     override def floor(left: BigDecimal): BigDecimal = Math.floor(left.doubleValue)
 
     override def ceil(left: BigDecimal): BigDecimal = Math.ceil(left.doubleValue)
+
+    override def round(left: BigDecimal): BigDecimal = Math.round(left.doubleValue)
   }
 }
 
@@ -303,6 +319,8 @@ object Fractional {
     override def floor(left: Float): Float = Math.floor(left.toDouble).toFloat
 
     override def ceil(left: Float): Float = Math.ceil(left).toFloat
+
+    override def round(left: Float): Float = Math.round(left)
   }
 
   implicit case object FractionalDouble extends Fractional[Double] {
@@ -338,6 +356,8 @@ object Fractional {
     override def floor(left: Double): Double = Math.floor(left)
 
     override def ceil(left: Double): Double = Math.ceil(left)
+
+    override def round(left: Double): Double = Math.round(left)
   }
 
   implicit case object FractionalBigDecimal extends Fractional[BigDecimal] {
@@ -375,5 +395,7 @@ object Fractional {
     override def floor(left: BigDecimal): BigDecimal = Math.floor(left.doubleValue)
 
     override def ceil(left: BigDecimal): BigDecimal = Math.ceil(left.doubleValue)
+
+    override def round(left: BigDecimal): BigDecimal = Math.round(left.doubleValue)
   }
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/numerics.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/numerics.scala
@@ -24,6 +24,8 @@ sealed trait Numeric[A] {
   def abs(left: A): A
 
   def min(left: A, right: A): A
+
+  def max(left: A, right: A): A
 }
 
 object Numeric extends NumericImplicits0 {
@@ -51,6 +53,8 @@ object Numeric extends NumericImplicits0 {
     override def abs(left: Int): Int = Math.abs(left)
 
     override def min(left: Int, right: Int): Int = Math.min(left, right)
+
+    override def max(left: Int, right: Int): Int = Math.max(left, right)
   }
 }
 
@@ -78,6 +82,8 @@ sealed trait NumericImplicits0 {
     override def abs(left: Short): Short = Math.abs(left).toShort
 
     override def min(left: Short, right: Short): Short = Math.min(left, right).toShort
+
+    override def max(left: Short, right: Short): Short = Math.max(left, right).toShort
   }
 
   implicit case object NumericLong extends Numeric[Long] {
@@ -102,6 +108,8 @@ sealed trait NumericImplicits0 {
     override def abs(left: Long): Long = Math.abs(left)
 
     override def min(left: Long, right: Long): Long = Math.min(left, right)
+
+    override def max(left: Long, right: Long): Long = Math.max(left, right)
   }
 
   implicit case object NumericBigInt extends Numeric[BigInt] {
@@ -130,6 +138,8 @@ sealed trait NumericImplicits0 {
     override def abs(left: BigInt): BigInt = Math.abs(left.toInt)
 
     override def min(left: BigInt, right: BigInt): BigInt = Math.min(left.toInt, right.toInt)
+
+    override def max(left: BigInt, right: BigInt): BigInt = Math.max(left.toInt, right.toInt)
   }
 
   implicit case object NumericFloat extends Numeric[Float] {
@@ -154,6 +164,8 @@ sealed trait NumericImplicits0 {
     override def abs(left: Float): Float = Math.abs(left)
 
     override def min(left: Float, right: Float): Float = Math.min(left, right)
+
+    override def max(left: Float, right: Float): Float = Math.max(left, right)
   }
 
   implicit case object NumericDouble extends Numeric[Double] {
@@ -178,6 +190,8 @@ sealed trait NumericImplicits0 {
     override def abs(left: Double): Double = Math.abs(left)
 
     override def min(left: Double, right: Double): Double = Math.min(left, right)
+
+    override def max(left: Double, right: Double): Double = Math.max(left, right)
   }
 
   implicit case object NumericBigDecimal extends Numeric[BigDecimal] {
@@ -206,6 +220,8 @@ sealed trait NumericImplicits0 {
     override def abs(left: BigDecimal): BigDecimal = Math.abs(left.doubleValue)
 
     override def min(left: BigDecimal, right: BigDecimal): BigDecimal = Math.min(left.doubleValue, right.doubleValue)
+
+    override def max(left: BigDecimal, right: BigDecimal): BigDecimal = Math.max(left.doubleValue, right.doubleValue)
   }
 }
 
@@ -247,6 +263,8 @@ object Fractional {
     override def abs(left: Float): Float = Math.abs(left)
 
     override def min(left: Float, right: Float): Float = Math.min(left, right)
+
+    override def max(left: Float, right: Float): Float = Math.max(left, right)
   }
 
   implicit case object FractionalDouble extends Fractional[Double] {
@@ -276,6 +294,8 @@ object Fractional {
     override def abs(left: Double): Double = Math.abs(left)
 
     override def min(left: Double, right: Double): Double = Math.min(left, right)
+
+    override def max(left: Double, right: Double): Double = Math.max(left, right)
   }
 
   implicit case object FractionalBigDecimal extends Fractional[BigDecimal] {
@@ -307,5 +327,7 @@ object Fractional {
     override def abs(left: BigDecimal): BigDecimal = Math.abs(left.doubleValue)
 
     override def min(left: BigDecimal, right: BigDecimal): BigDecimal = Math.min(left.doubleValue, right.doubleValue)
+
+    override def max(left: BigDecimal, right: BigDecimal): BigDecimal = Math.max(left.doubleValue, right.doubleValue)
   }
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/numerics.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/numerics.scala
@@ -323,7 +323,7 @@ object Fractional {
     override def ceil(left: Float): Float = Math.ceil(left).toFloat
 
     override def round(left: Float): Float = Math.round(left)
-    
+
     override def inverseSin(a: Float): Float = Math.asin(a.toDouble).toFloat
 
     override def inverseTan(a: Float): Float = Math.atan(a.toDouble).toFloat
@@ -365,7 +365,7 @@ object Fractional {
     override def ceil(left: Double): Double = Math.ceil(left)
 
     override def round(left: Double): Double = Math.round(left)
-    
+
     override def inverseSin(a: Double): Double = Math.asin(a)
 
     override def inverseTan(a: Double): Double = Math.atan(a)
@@ -409,6 +409,7 @@ object Fractional {
     override def ceil(left: BigDecimal): BigDecimal = Math.ceil(left.doubleValue)
 
     override def round(left: BigDecimal): BigDecimal = Math.round(left.doubleValue)
+
     override def inverseSin(a: BigDecimal): BigDecimal = Math.asin(a.doubleValue)
 
     override def inverseTan(a: BigDecimal): BigDecimal =

--- a/zio-flow/shared/src/main/scala/zio/flow/numerics.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/numerics.scala
@@ -20,6 +20,8 @@ sealed trait Numeric[A] {
   def root(left: A, right: A): A
 
   def log(left: A, right: A): A
+
+  def abs(left: A): A
 }
 
 object Numeric extends NumericImplicits0 {
@@ -43,6 +45,8 @@ object Numeric extends NumericImplicits0 {
     override def negate(left: Int): Int = -1 * left
 
     def mod(left: Int, right: Int): Int = left % right
+
+    override def abs(left: Int): Int = Math.abs(left)
   }
 }
 
@@ -66,6 +70,8 @@ sealed trait NumericImplicits0 {
     override def negate(left: Short): Short = (-1 * left).toShort
 
     def schema: Schema[Short] = implicitly[Schema[Short]]
+
+    override def abs(left: Short): Short = Math.abs(left).toShort
   }
 
   implicit case object NumericLong extends Numeric[Long] {
@@ -86,6 +92,8 @@ sealed trait NumericImplicits0 {
     override def log(left: Long, right: Long): Long = (Math.log(left.toDouble) / Math.log(right.toDouble)).toLong
 
     def schema: Schema[Long] = implicitly[Schema[Long]]
+
+    override def abs(left: Long): Long = Math.abs(left)
   }
 
   implicit case object NumericBigInt extends Numeric[BigInt] {
@@ -110,6 +118,8 @@ sealed trait NumericImplicits0 {
     )
 
     def schema: Schema[BigInt] = implicitly[Schema[BigInt]]
+
+    override def abs(left: BigInt): BigInt = Math.abs(left.toInt)
   }
 
   implicit case object NumericFloat extends Numeric[Float] {
@@ -130,6 +140,8 @@ sealed trait NumericImplicits0 {
     override def log(left: Float, right: Float): Float = (Math.log(left.toDouble) / Math.log(right.toDouble)).toFloat
 
     def schema: Schema[Float] = implicitly[Schema[Float]]
+
+    override def abs(left: Float): Float = Math.abs(left)
   }
 
   implicit case object NumericDouble extends Numeric[Double] {
@@ -150,6 +162,8 @@ sealed trait NumericImplicits0 {
     override def log(left: Double, right: Double): Double = Math.log(left) / Math.log(right)
 
     def schema: Schema[Double] = implicitly[Schema[Double]]
+
+    override def abs(left: Double): Double = Math.abs(left)
   }
 
   implicit case object NumericBigDecimal extends Numeric[BigDecimal] {
@@ -174,6 +188,8 @@ sealed trait NumericImplicits0 {
     override def negate(left: BigDecimal): BigDecimal = -1 * left
 
     def schema: Schema[BigDecimal] = implicitly[Schema[BigDecimal]]
+
+    override def abs(left: BigDecimal): BigDecimal = Math.abs(left.doubleValue)
   }
 }
 
@@ -211,6 +227,8 @@ object Fractional {
     override def sin(a: Float): Float = Math.sin(a.toDouble).toFloat
 
     def schema: Schema[Float] = implicitly[Schema[Float]]
+
+    override def abs(left: Float): Float = Math.abs(left)
   }
 
   implicit case object FractionalDouble extends Fractional[Double] {
@@ -236,6 +254,8 @@ object Fractional {
     override def sin(a: Double): Double = Math.sin(a)
 
     def schema: Schema[Double] = implicitly[Schema[Double]]
+
+    override def abs(left: Double): Double = Math.abs(left)
   }
 
   implicit case object FractionalBigDecimal extends Fractional[BigDecimal] {
@@ -263,5 +283,7 @@ object Fractional {
     override def sin(a: BigDecimal): BigDecimal = Math.sin(a.doubleValue)
 
     def schema: Schema[BigDecimal] = implicitly[Schema[BigDecimal]]
+
+    override def abs(left: BigDecimal): BigDecimal = Math.abs(left.doubleValue)
   }
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/numerics.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/numerics.scala
@@ -22,6 +22,8 @@ sealed trait Numeric[A] {
   def log(left: A, right: A): A
 
   def abs(left: A): A
+
+  def min(left: A, right: A): A
 }
 
 object Numeric extends NumericImplicits0 {
@@ -47,6 +49,8 @@ object Numeric extends NumericImplicits0 {
     def mod(left: Int, right: Int): Int = left % right
 
     override def abs(left: Int): Int = Math.abs(left)
+
+    override def min(left: Int, right: Int): Int = Math.min(left, right)
   }
 }
 
@@ -72,6 +76,8 @@ sealed trait NumericImplicits0 {
     def schema: Schema[Short] = implicitly[Schema[Short]]
 
     override def abs(left: Short): Short = Math.abs(left).toShort
+
+    override def min(left: Short, right: Short): Short = Math.min(left, right).toShort
   }
 
   implicit case object NumericLong extends Numeric[Long] {
@@ -94,6 +100,8 @@ sealed trait NumericImplicits0 {
     def schema: Schema[Long] = implicitly[Schema[Long]]
 
     override def abs(left: Long): Long = Math.abs(left)
+
+    override def min(left: Long, right: Long): Long = Math.min(left, right)
   }
 
   implicit case object NumericBigInt extends Numeric[BigInt] {
@@ -120,6 +128,8 @@ sealed trait NumericImplicits0 {
     def schema: Schema[BigInt] = implicitly[Schema[BigInt]]
 
     override def abs(left: BigInt): BigInt = Math.abs(left.toInt)
+
+    override def min(left: BigInt, right: BigInt): BigInt = Math.min(left.toInt, right.toInt)
   }
 
   implicit case object NumericFloat extends Numeric[Float] {
@@ -142,6 +152,8 @@ sealed trait NumericImplicits0 {
     def schema: Schema[Float] = implicitly[Schema[Float]]
 
     override def abs(left: Float): Float = Math.abs(left)
+
+    override def min(left: Float, right: Float): Float = Math.min(left, right)
   }
 
   implicit case object NumericDouble extends Numeric[Double] {
@@ -164,6 +176,8 @@ sealed trait NumericImplicits0 {
     def schema: Schema[Double] = implicitly[Schema[Double]]
 
     override def abs(left: Double): Double = Math.abs(left)
+
+    override def min(left: Double, right: Double): Double = Math.min(left, right)
   }
 
   implicit case object NumericBigDecimal extends Numeric[BigDecimal] {
@@ -190,6 +204,8 @@ sealed trait NumericImplicits0 {
     def schema: Schema[BigDecimal] = implicitly[Schema[BigDecimal]]
 
     override def abs(left: BigDecimal): BigDecimal = Math.abs(left.doubleValue)
+
+    override def min(left: BigDecimal, right: BigDecimal): BigDecimal = Math.min(left.doubleValue, right.doubleValue)
   }
 }
 
@@ -229,6 +245,8 @@ object Fractional {
     def schema: Schema[Float] = implicitly[Schema[Float]]
 
     override def abs(left: Float): Float = Math.abs(left)
+
+    override def min(left: Float, right: Float): Float = Math.min(left, right)
   }
 
   implicit case object FractionalDouble extends Fractional[Double] {
@@ -256,6 +274,8 @@ object Fractional {
     def schema: Schema[Double] = implicitly[Schema[Double]]
 
     override def abs(left: Double): Double = Math.abs(left)
+
+    override def min(left: Double, right: Double): Double = Math.min(left, right)
   }
 
   implicit case object FractionalBigDecimal extends Fractional[BigDecimal] {
@@ -285,5 +305,7 @@ object Fractional {
     def schema: Schema[BigDecimal] = implicitly[Schema[BigDecimal]]
 
     override def abs(left: BigDecimal): BigDecimal = Math.abs(left.doubleValue)
+
+    override def min(left: BigDecimal, right: BigDecimal): BigDecimal = Math.min(left.doubleValue, right.doubleValue)
   }
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/numerics.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/numerics.scala
@@ -26,6 +26,9 @@ sealed trait Numeric[A] {
   def min(left: A, right: A): A
 
   def max(left: A, right: A): A
+
+  def floor(left: A): A
+
 }
 
 object Numeric extends NumericImplicits0 {
@@ -55,6 +58,8 @@ object Numeric extends NumericImplicits0 {
     override def min(left: Int, right: Int): Int = Math.min(left, right)
 
     override def max(left: Int, right: Int): Int = Math.max(left, right)
+
+    override def floor(left: Int): Int = Math.floor(left.toDouble).toInt
   }
 }
 
@@ -84,6 +89,8 @@ sealed trait NumericImplicits0 {
     override def min(left: Short, right: Short): Short = Math.min(left, right).toShort
 
     override def max(left: Short, right: Short): Short = Math.max(left, right).toShort
+
+    override def floor(left: Short): Short = Math.floor(left.toDouble).toShort
   }
 
   implicit case object NumericLong extends Numeric[Long] {
@@ -110,6 +117,8 @@ sealed trait NumericImplicits0 {
     override def min(left: Long, right: Long): Long = Math.min(left, right)
 
     override def max(left: Long, right: Long): Long = Math.max(left, right)
+
+    override def floor(left: Long): Long = Math.floor(left.toDouble).toLong
   }
 
   implicit case object NumericBigInt extends Numeric[BigInt] {
@@ -140,6 +149,8 @@ sealed trait NumericImplicits0 {
     override def min(left: BigInt, right: BigInt): BigInt = Math.min(left.toInt, right.toInt)
 
     override def max(left: BigInt, right: BigInt): BigInt = Math.max(left.toInt, right.toInt)
+
+    override def floor(left: BigInt): BigInt = Math.floor(left.doubleValue).toInt
   }
 
   implicit case object NumericFloat extends Numeric[Float] {
@@ -166,6 +177,8 @@ sealed trait NumericImplicits0 {
     override def min(left: Float, right: Float): Float = Math.min(left, right)
 
     override def max(left: Float, right: Float): Float = Math.max(left, right)
+
+    override def floor(left: Float): Float = Math.floor(left.toDouble).toFloat
   }
 
   implicit case object NumericDouble extends Numeric[Double] {
@@ -192,6 +205,8 @@ sealed trait NumericImplicits0 {
     override def min(left: Double, right: Double): Double = Math.min(left, right)
 
     override def max(left: Double, right: Double): Double = Math.max(left, right)
+
+    override def floor(left: Double): Double = Math.floor(left)
   }
 
   implicit case object NumericBigDecimal extends Numeric[BigDecimal] {
@@ -222,6 +237,8 @@ sealed trait NumericImplicits0 {
     override def min(left: BigDecimal, right: BigDecimal): BigDecimal = Math.min(left.doubleValue, right.doubleValue)
 
     override def max(left: BigDecimal, right: BigDecimal): BigDecimal = Math.max(left.doubleValue, right.doubleValue)
+
+    override def floor(left: BigDecimal): BigDecimal = Math.floor(left.doubleValue)
   }
 }
 
@@ -233,6 +250,7 @@ sealed trait Fractional[A] extends Numeric[A] {
   def sin(a: A): A
 
   def inverseSin(a: A): A = ???
+
 }
 
 object Fractional {
@@ -265,6 +283,8 @@ object Fractional {
     override def min(left: Float, right: Float): Float = Math.min(left, right)
 
     override def max(left: Float, right: Float): Float = Math.max(left, right)
+
+    override def floor(left: Float): Float = Math.floor(left.toDouble).toFloat
   }
 
   implicit case object FractionalDouble extends Fractional[Double] {
@@ -296,6 +316,8 @@ object Fractional {
     override def min(left: Double, right: Double): Double = Math.min(left, right)
 
     override def max(left: Double, right: Double): Double = Math.max(left, right)
+
+    override def floor(left: Double): Double = Math.floor(left)
   }
 
   implicit case object FractionalBigDecimal extends Fractional[BigDecimal] {
@@ -329,5 +351,7 @@ object Fractional {
     override def min(left: BigDecimal, right: BigDecimal): BigDecimal = Math.min(left.doubleValue, right.doubleValue)
 
     override def max(left: BigDecimal, right: BigDecimal): BigDecimal = Math.max(left.doubleValue, right.doubleValue)
+
+    override def floor(left: BigDecimal): BigDecimal = Math.floor(left.doubleValue)
   }
 }

--- a/zio-flow/shared/src/test/scala/zio/flow/NumericSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/NumericSpec.scala
@@ -110,8 +110,8 @@ object NumericSpec extends DefaultRunnableSpec {
         min = Math.min,
         max = Math.max,
         floor = x => Math.floor(x.toDouble).toInt,
-        ceil = x => Math.ceil(x).toInt,
-        round = x => Math.round(x)
+        ceil = x => Math.ceil(x.toDouble).toInt,
+        round = x => Math.round(x.toDouble).toInt
       )
 
     val bigIntOperations: NumericOps[BigInt] =
@@ -160,9 +160,9 @@ object NumericSpec extends DefaultRunnableSpec {
         abs = x => Math.abs(x),
         min = Math.min,
         max = Math.max,
-        floor = x => Math.floor(x).toLong,
-        ceil = x => Math.ceil(x).toLong,
-        round = x => Math.round(x)
+        floor = x => Math.floor(x.toDouble).toLong,
+        ceil = x => Math.ceil(x.toDouble).toLong,
+        round = x => Math.round(x.toDouble)
       )
 
     val shortOperations: NumericOps[Short] =
@@ -174,12 +174,12 @@ object NumericSpec extends DefaultRunnableSpec {
         isZero = _ == 0,
         log = (x, y) => (Math.log(x.toDouble) / Math.log(y.toDouble)).toShort,
         root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toShort,
-        abs = x => Math.abs(x).toShort,
+        abs = x => Math.abs(x.toDouble).toShort,
         min = (x, y) => Math.min(x.toDouble, y.toDouble).toShort,
         max = (x, y) => Math.max(x.toDouble, y.toDouble).toShort,
         floor = x => Math.floor(x.toDouble).toShort,
-        ceil = x => Math.ceil(x).toShort,
-        round = x => Math.round(x).toShort
+        ceil = x => Math.ceil(x.toDouble).toShort,
+        round = x => Math.round(x.toDouble).toShort
       )
 
     val doubleOperations: NumericOps[Double] = NumericOps[Double](
@@ -195,7 +195,7 @@ object NumericSpec extends DefaultRunnableSpec {
       max = Math.max,
       floor = Math.floor,
       ceil = x => Math.ceil(x),
-      round = x => Math.round(x)
+      round = x => Math.round(x).toDouble
     )
 
     val floatOperations: NumericOps[Float] = NumericOps[Float](
@@ -210,8 +210,8 @@ object NumericSpec extends DefaultRunnableSpec {
       min = Math.min,
       max = Math.max,
       floor = x => Math.floor(x.toDouble).toFloat,
-      ceil = x => Math.ceil(x).toFloat,
-      round = x => Math.round(x)
+      ceil = x => Math.ceil(x.toDouble).toFloat,
+      round = x => Math.round(x.toDouble).toFloat
     )
   }
 }

--- a/zio-flow/shared/src/test/scala/zio/flow/NumericSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/NumericSpec.scala
@@ -36,7 +36,8 @@ object NumericSpec extends DefaultRunnableSpec {
       testOp[R, A]("Minimum", gen, gen)(_ min _)(ops.min),
       testOp[R, A]("Maximum", gen, gen)(_ max _)(ops.max),
       testOp[R, A]("Floor", gen)(_.floor)(ops.floor),
-      testOp[R, A]("Ceil", gen)(_.ceil)(ops.ceil)
+      testOp[R, A]("Ceil", gen)(_.ceil)(ops.ceil),
+      testOp[R, A]("Round", gen)(_.ceil)(ops.ceil)
     )
 
   // TODO: BigDecimal fails Log/Root specs.
@@ -53,7 +54,10 @@ object NumericSpec extends DefaultRunnableSpec {
       testOp[R, A]("Division", gen, gen.filterNot(ops.isZero))(_ / _)(ops.division),
       testOp[R, A]("Absolute", gen)(_.abs)(ops.abs),
       testOp[R, A]("Minimum", gen, gen)(_ min _)(ops.min),
-      testOp[R, A]("Maximum", gen, gen)(_ max _)(ops.max)
+      testOp[R, A]("Maximum", gen, gen)(_ max _)(ops.max),
+      testOp[R, A]("Floor", gen)(_.floor)(ops.floor),
+      testOp[R, A]("Ceil", gen)(_.ceil)(ops.ceil),
+      testOp[R, A]("Round", gen)(_.ceil)(ops.ceil)
 //      testOp[R, A]("Log", gen, gen)(_ log _)(ops.log),
 //      testOp[R, A]("Root", gen, gen)(_ root _)(ops.root)
     )
@@ -88,7 +92,8 @@ object NumericSpec extends DefaultRunnableSpec {
     min: (A, A) => A,
     max: (A, A) => A,
     floor: A => A,
-    ceil: A => A
+    ceil: A => A,
+    round: A => A
   )
 
   private object Operations {
@@ -105,7 +110,8 @@ object NumericSpec extends DefaultRunnableSpec {
         min = Math.min,
         max = Math.max,
         floor = x => Math.floor(x.toDouble).toInt,
-        ceil = x => Math.ceil(x).toInt
+        ceil = x => Math.ceil(x).toInt,
+        round = x => Math.round(x)
       )
 
     val bigIntOperations: NumericOps[BigInt] =
@@ -121,7 +127,8 @@ object NumericSpec extends DefaultRunnableSpec {
         min = (x, y) => Math.min(x.doubleValue, y.doubleValue).toInt,
         max = (x, y) => Math.max(x.doubleValue, y.doubleValue).toInt,
         floor = x => Math.floor(x.doubleValue).toInt,
-        ceil = x => Math.ceil(x.doubleValue).toInt
+        ceil = x => Math.ceil(x.doubleValue).toInt,
+        round = x => Math.round(x.doubleValue)
       )
 
     val bigDecimalOperations: NumericOps[BigDecimal] =
@@ -137,7 +144,8 @@ object NumericSpec extends DefaultRunnableSpec {
         min = (x, y) => Math.min(x.doubleValue, y.doubleValue),
         max = (x, y) => Math.max(x.doubleValue, y.doubleValue),
         floor = x => Math.floor(x.doubleValue),
-        ceil = x => Math.ceil(x.doubleValue)
+        ceil = x => Math.ceil(x.doubleValue),
+        round = x => Math.round(x.doubleValue)
       )
 
     val longOperations: NumericOps[Long] =
@@ -153,7 +161,8 @@ object NumericSpec extends DefaultRunnableSpec {
         min = Math.min,
         max = Math.max,
         floor = x => Math.floor(x).toLong,
-        ceil = x => Math.ceil(x).toLong
+        ceil = x => Math.ceil(x).toLong,
+        round = x => Math.round(x)
       )
 
     val shortOperations: NumericOps[Short] =
@@ -169,7 +178,8 @@ object NumericSpec extends DefaultRunnableSpec {
         min = (x, y) => Math.min(x.toDouble, y.toDouble).toShort,
         max = (x, y) => Math.max(x.toDouble, y.toDouble).toShort,
         floor = x => Math.floor(x.toDouble).toShort,
-        ceil = x => Math.ceil(x).toShort
+        ceil = x => Math.ceil(x).toShort,
+        round = x => Math.round(x).toShort
       )
 
     val doubleOperations: NumericOps[Double] = NumericOps[Double](
@@ -184,7 +194,8 @@ object NumericSpec extends DefaultRunnableSpec {
       min = Math.min,
       max = Math.max,
       floor = Math.floor,
-      ceil = x => Math.ceil(x)
+      ceil = x => Math.ceil(x),
+      round = x => Math.round(x)
     )
 
     val floatOperations: NumericOps[Float] = NumericOps[Float](
@@ -199,7 +210,8 @@ object NumericSpec extends DefaultRunnableSpec {
       min = Math.min,
       max = Math.max,
       floor = x => Math.floor(x.toDouble).toFloat,
-      ceil = x => Math.ceil(x).toFloat
+      ceil = x => Math.ceil(x).toFloat,
+      round = x => Math.round(x)
     )
   }
 }

--- a/zio-flow/shared/src/test/scala/zio/flow/NumericSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/NumericSpec.scala
@@ -32,7 +32,8 @@ object NumericSpec extends DefaultRunnableSpec {
       testOp[R, A]("Division", gen, gen.filterNot(ops.isZero))(_ / _)(ops.division),
       testOp[R, A]("Log", gen, gen)(_ log _)(ops.log),
       testOp[R, A]("Root", gen, gen)(_ root _)(ops.root),
-      testOp[R, A]("Absolute", gen)(_.abs)(ops.abs)
+      testOp[R, A]("Absolute", gen)(_.abs)(ops.abs),
+      testOp[R, A]("Minimum", gen, gen)(_ + _)(ops.min)
     )
 
   // TODO: BigDecimal fails Log/Root specs.
@@ -78,7 +79,8 @@ object NumericSpec extends DefaultRunnableSpec {
     isZero: A => Boolean,
     log: (A, A) => A,
     root: (A, A) => A,
-    abs: A => A
+    abs: A => A,
+    min: (A, A) => A
   )
 
   private object Operations {
@@ -91,7 +93,8 @@ object NumericSpec extends DefaultRunnableSpec {
         isZero = _ == 0,
         log = (x, y) => (Math.log(x.toDouble) / Math.log(y.toDouble)).toInt,
         root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toInt,
-        abs = x => Math.abs(x)
+        abs = x => Math.abs(x),
+        min = Math.min
       )
 
     val bigIntOperations: NumericOps[BigInt] =
@@ -103,7 +106,8 @@ object NumericSpec extends DefaultRunnableSpec {
         isZero = _ == 0,
         log = (x, y) => (Math.log(x.doubleValue) / Math.log(y.doubleValue)).toInt,
         root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toInt,
-        abs = x => Math.abs(x.doubleValue).toInt
+        abs = x => Math.abs(x.doubleValue).toInt,
+        min = (x, y) => Math.min(x.doubleValue, y.doubleValue).toInt
       )
 
     val bigDecimalOperations: NumericOps[BigDecimal] =
@@ -115,7 +119,8 @@ object NumericSpec extends DefaultRunnableSpec {
         isZero = _ == 0,
         log = (x, y) => Math.log(x.doubleValue) / Math.log(y.doubleValue),
         root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble),
-        abs = x => Math.abs(x.doubleValue)
+        abs = x => Math.abs(x.doubleValue),
+        min = (x, y) => Math.min(x.doubleValue, y.doubleValue)
       )
 
     val longOperations: NumericOps[Long] =
@@ -127,7 +132,8 @@ object NumericSpec extends DefaultRunnableSpec {
         isZero = _ == 0,
         log = (x, y) => (Math.log(x.toDouble) / Math.log(y.toDouble)).toLong,
         root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toLong,
-        abs = x => Math.abs(x)
+        abs = x => Math.abs(x),
+        min = Math.min
       )
 
     val shortOperations: NumericOps[Short] =
@@ -139,7 +145,8 @@ object NumericSpec extends DefaultRunnableSpec {
         isZero = _ == 0,
         log = (x, y) => (Math.log(x.toDouble) / Math.log(y.toDouble)).toShort,
         root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toShort,
-        abs = x => Math.abs(x).toShort
+        abs = x => Math.abs(x).toShort,
+        min = (x, y) => Math.min(x.toDouble, y.toDouble).toShort
       )
 
     val doubleOperations: NumericOps[Double] = NumericOps[Double](
@@ -150,7 +157,8 @@ object NumericSpec extends DefaultRunnableSpec {
       isZero = _ == 0,
       log = (x, y) => Math.log(x) / Math.log(y),
       root = (x, y) => Math.pow(x, 1 / y),
-      abs = x => Math.abs(x)
+      abs = x => Math.abs(x),
+      min = Math.min
     )
 
     val floatOperations: NumericOps[Float] = NumericOps[Float](
@@ -161,7 +169,8 @@ object NumericSpec extends DefaultRunnableSpec {
       isZero = _ == 0,
       log = (x, y) => (Math.log(x.toDouble) / Math.log(y.toDouble)).toFloat,
       root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toFloat,
-      abs = x => Math.abs(x)
+      abs = x => Math.abs(x),
+      min = Math.min
     )
   }
 }

--- a/zio-flow/shared/src/test/scala/zio/flow/NumericSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/NumericSpec.scala
@@ -35,7 +35,8 @@ object NumericSpec extends DefaultRunnableSpec {
       testOp[R, A]("Absolute", gen)(_.abs)(ops.abs),
       testOp[R, A]("Minimum", gen, gen)(_ min _)(ops.min),
       testOp[R, A]("Maximum", gen, gen)(_ max _)(ops.max),
-      testOp[R, A]("Floor", gen)(_.floor)(ops.floor)
+      testOp[R, A]("Floor", gen)(_.floor)(ops.floor),
+      testOp[R, A]("Ceil", gen)(_.ceil)(ops.ceil)
     )
 
   // TODO: BigDecimal fails Log/Root specs.
@@ -86,7 +87,8 @@ object NumericSpec extends DefaultRunnableSpec {
     abs: A => A,
     min: (A, A) => A,
     max: (A, A) => A,
-    floor: A => A
+    floor: A => A,
+    ceil: A => A
   )
 
   private object Operations {
@@ -102,7 +104,8 @@ object NumericSpec extends DefaultRunnableSpec {
         abs = x => Math.abs(x),
         min = Math.min,
         max = Math.max,
-        floor = x => Math.floor(x.toDouble).toInt
+        floor = x => Math.floor(x.toDouble).toInt,
+        ceil = x => Math.ceil(x).toInt
       )
 
     val bigIntOperations: NumericOps[BigInt] =
@@ -117,7 +120,8 @@ object NumericSpec extends DefaultRunnableSpec {
         abs = x => Math.abs(x.doubleValue).toInt,
         min = (x, y) => Math.min(x.doubleValue, y.doubleValue).toInt,
         max = (x, y) => Math.max(x.doubleValue, y.doubleValue).toInt,
-        floor = x => Math.floor(x.doubleValue).toInt
+        floor = x => Math.floor(x.doubleValue).toInt,
+        ceil = x => Math.ceil(x.doubleValue).toInt
       )
 
     val bigDecimalOperations: NumericOps[BigDecimal] =
@@ -132,7 +136,8 @@ object NumericSpec extends DefaultRunnableSpec {
         abs = x => Math.abs(x.doubleValue),
         min = (x, y) => Math.min(x.doubleValue, y.doubleValue),
         max = (x, y) => Math.max(x.doubleValue, y.doubleValue),
-        floor = x => Math.floor(x.doubleValue)
+        floor = x => Math.floor(x.doubleValue),
+        ceil = x => Math.ceil(x.doubleValue)
       )
 
     val longOperations: NumericOps[Long] =
@@ -147,7 +152,8 @@ object NumericSpec extends DefaultRunnableSpec {
         abs = x => Math.abs(x),
         min = Math.min,
         max = Math.max,
-        floor = x => Math.floor(x).toLong
+        floor = x => Math.floor(x).toLong,
+        ceil = x => Math.ceil(x).toLong
       )
 
     val shortOperations: NumericOps[Short] =
@@ -162,7 +168,8 @@ object NumericSpec extends DefaultRunnableSpec {
         abs = x => Math.abs(x).toShort,
         min = (x, y) => Math.min(x.toDouble, y.toDouble).toShort,
         max = (x, y) => Math.max(x.toDouble, y.toDouble).toShort,
-        floor = x => Math.floor(x.toDouble).toShort
+        floor = x => Math.floor(x.toDouble).toShort,
+        ceil = x => Math.ceil(x).toShort
       )
 
     val doubleOperations: NumericOps[Double] = NumericOps[Double](
@@ -176,7 +183,8 @@ object NumericSpec extends DefaultRunnableSpec {
       abs = x => Math.abs(x),
       min = Math.min,
       max = Math.max,
-      floor = Math.floor
+      floor = Math.floor,
+      ceil = x => Math.ceil(x)
     )
 
     val floatOperations: NumericOps[Float] = NumericOps[Float](
@@ -190,7 +198,8 @@ object NumericSpec extends DefaultRunnableSpec {
       abs = x => Math.abs(x),
       min = Math.min,
       max = Math.max,
-      floor = x => Math.floor(x.toDouble).toFloat
+      floor = x => Math.floor(x.toDouble).toFloat,
+      ceil = x => Math.ceil(x).toFloat
     )
   }
 }

--- a/zio-flow/shared/src/test/scala/zio/flow/NumericSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/NumericSpec.scala
@@ -33,8 +33,8 @@ object NumericSpec extends DefaultRunnableSpec {
       testOp[R, A]("Log", gen, gen)(_ log _)(ops.log),
       testOp[R, A]("Root", gen, gen)(_ root _)(ops.root),
       testOp[R, A]("Absolute", gen)(_.abs)(ops.abs),
-      testOp[R, A]("Minimum", gen, gen)(_ + _)(ops.min),
-      testOp[R, A]("Maximum", gen, gen)(_ + _)(ops.max)
+      testOp[R, A]("Minimum", gen, gen)(_ min  _)(ops.min),
+      testOp[R, A]("Maximum", gen, gen)(_ max  _)(ops.max)
     )
 
   // TODO: BigDecimal fails Log/Root specs.
@@ -50,7 +50,8 @@ object NumericSpec extends DefaultRunnableSpec {
       testOp[R, A]("Multiplication", gen, gen)(_ * _)(ops.multiplication),
       testOp[R, A]("Division", gen, gen.filterNot(ops.isZero))(_ / _)(ops.division),
       testOp[R, A]("Absolute", gen)(_.abs)(ops.abs),
-      testOp[R, A]("Minimum", gen, gen)(_ + _)(ops.min)
+      testOp[R, A]("Minimum", gen, gen)(_ min _)(ops.min),
+      testOp[R, A]("Maximum", gen, gen)(_ max _)(ops.max)
 //      testOp[R, A]("Log", gen, gen)(_ log _)(ops.log),
 //      testOp[R, A]("Root", gen, gen)(_ root _)(ops.root)
     )

--- a/zio-flow/shared/src/test/scala/zio/flow/NumericSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/NumericSpec.scala
@@ -33,8 +33,9 @@ object NumericSpec extends DefaultRunnableSpec {
       testOp[R, A]("Log", gen, gen)(_ log _)(ops.log),
       testOp[R, A]("Root", gen, gen)(_ root _)(ops.root),
       testOp[R, A]("Absolute", gen)(_.abs)(ops.abs),
-      testOp[R, A]("Minimum", gen, gen)(_ min  _)(ops.min),
-      testOp[R, A]("Maximum", gen, gen)(_ max  _)(ops.max)
+      testOp[R, A]("Minimum", gen, gen)(_ min _)(ops.min),
+      testOp[R, A]("Maximum", gen, gen)(_ max _)(ops.max),
+      testOp[R, A]("Floor", gen)(_.floor)(ops.floor)
     )
 
   // TODO: BigDecimal fails Log/Root specs.
@@ -84,7 +85,8 @@ object NumericSpec extends DefaultRunnableSpec {
     root: (A, A) => A,
     abs: A => A,
     min: (A, A) => A,
-    max: (A, A) => A
+    max: (A, A) => A,
+    floor: A => A
   )
 
   private object Operations {
@@ -99,7 +101,8 @@ object NumericSpec extends DefaultRunnableSpec {
         root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toInt,
         abs = x => Math.abs(x),
         min = Math.min,
-        max = Math.max
+        max = Math.max,
+        floor = x => Math.floor(x.toDouble).toInt
       )
 
     val bigIntOperations: NumericOps[BigInt] =
@@ -113,7 +116,8 @@ object NumericSpec extends DefaultRunnableSpec {
         root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toInt,
         abs = x => Math.abs(x.doubleValue).toInt,
         min = (x, y) => Math.min(x.doubleValue, y.doubleValue).toInt,
-        max = (x, y) => Math.max(x.doubleValue, y.doubleValue).toInt
+        max = (x, y) => Math.max(x.doubleValue, y.doubleValue).toInt,
+        floor = x => Math.floor(x.doubleValue).toInt
       )
 
     val bigDecimalOperations: NumericOps[BigDecimal] =
@@ -127,7 +131,8 @@ object NumericSpec extends DefaultRunnableSpec {
         root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble),
         abs = x => Math.abs(x.doubleValue),
         min = (x, y) => Math.min(x.doubleValue, y.doubleValue),
-        max = (x, y) => Math.max(x.doubleValue, y.doubleValue)
+        max = (x, y) => Math.max(x.doubleValue, y.doubleValue),
+        floor = x => Math.floor(x.doubleValue)
       )
 
     val longOperations: NumericOps[Long] =
@@ -141,7 +146,8 @@ object NumericSpec extends DefaultRunnableSpec {
         root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toLong,
         abs = x => Math.abs(x),
         min = Math.min,
-        max = Math.max
+        max = Math.max,
+        floor = x => Math.floor(x).toLong
       )
 
     val shortOperations: NumericOps[Short] =
@@ -155,7 +161,8 @@ object NumericSpec extends DefaultRunnableSpec {
         root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toShort,
         abs = x => Math.abs(x).toShort,
         min = (x, y) => Math.min(x.toDouble, y.toDouble).toShort,
-        max = (x, y) => Math.max(x.toDouble, y.toDouble).toShort
+        max = (x, y) => Math.max(x.toDouble, y.toDouble).toShort,
+        floor = x => Math.floor(x.toDouble).toShort
       )
 
     val doubleOperations: NumericOps[Double] = NumericOps[Double](
@@ -168,7 +175,8 @@ object NumericSpec extends DefaultRunnableSpec {
       root = (x, y) => Math.pow(x, 1 / y),
       abs = x => Math.abs(x),
       min = Math.min,
-      max = Math.max
+      max = Math.max,
+      floor = Math.floor
     )
 
     val floatOperations: NumericOps[Float] = NumericOps[Float](
@@ -181,7 +189,8 @@ object NumericSpec extends DefaultRunnableSpec {
       root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toFloat,
       abs = x => Math.abs(x),
       min = Math.min,
-      max = Math.max
+      max = Math.max,
+      floor = x => Math.floor(x.toDouble).toFloat
     )
   }
 }

--- a/zio-flow/shared/src/test/scala/zio/flow/NumericSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/NumericSpec.scala
@@ -31,7 +31,8 @@ object NumericSpec extends DefaultRunnableSpec {
       testOp[R, A]("Multiplication", gen, gen)(_ * _)(ops.multiplication),
       testOp[R, A]("Division", gen, gen.filterNot(ops.isZero))(_ / _)(ops.division),
       testOp[R, A]("Log", gen, gen)(_ log _)(ops.log),
-      testOp[R, A]("Root", gen, gen)(_ root _)(ops.root)
+      testOp[R, A]("Root", gen, gen)(_ root _)(ops.root),
+      testOp[R, A]("Absolute", gen)(_.abs)(ops.abs)
     )
 
   // TODO: BigDecimal fails Log/Root specs.
@@ -45,7 +46,8 @@ object NumericSpec extends DefaultRunnableSpec {
         ops.subtraction
       ) @@ TestAspect.exceptScala211 @@ TestAspect.exceptScala212,
       testOp[R, A]("Multiplication", gen, gen)(_ * _)(ops.multiplication),
-      testOp[R, A]("Division", gen, gen.filterNot(ops.isZero))(_ / _)(ops.division)
+      testOp[R, A]("Division", gen, gen.filterNot(ops.isZero))(_ / _)(ops.division),
+      testOp[R, A]("Absolute", gen)(_.abs)(ops.abs)
 //      testOp[R, A]("Log", gen, gen)(_ log _)(ops.log),
 //      testOp[R, A]("Root", gen, gen)(_ root _)(ops.root)
     )
@@ -59,6 +61,15 @@ object NumericSpec extends DefaultRunnableSpec {
       }
     }
 
+  private def testOp[R, A: Schema: Numeric](name: String, gen: Gen[R, A])(
+    numericOp: Remote[A] => Remote[A]
+  )(op: A => A): ZSpec[R with TestConfig, Nothing] =
+    testM(name) {
+      check(gen) { x =>
+        numericOp(x) <-> op(x)
+      }
+    }
+
   private case class NumericOps[A](
     addition: (A, A) => A,
     subtraction: (A, A) => A,
@@ -66,7 +77,8 @@ object NumericSpec extends DefaultRunnableSpec {
     division: (A, A) => A,
     isZero: A => Boolean,
     log: (A, A) => A,
-    root: (A, A) => A
+    root: (A, A) => A,
+    abs: A => A
   )
 
   private object Operations {
@@ -78,7 +90,8 @@ object NumericSpec extends DefaultRunnableSpec {
         division = _ / _,
         isZero = _ == 0,
         log = (x, y) => (Math.log(x.toDouble) / Math.log(y.toDouble)).toInt,
-        root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toInt
+        root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toInt,
+        abs = x => Math.abs(x)
       )
 
     val bigIntOperations: NumericOps[BigInt] =
@@ -89,7 +102,8 @@ object NumericSpec extends DefaultRunnableSpec {
         division = _ / _,
         isZero = _ == 0,
         log = (x, y) => (Math.log(x.doubleValue) / Math.log(y.doubleValue)).toInt,
-        root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toInt
+        root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toInt,
+        abs = x => Math.abs(x.doubleValue).toInt
       )
 
     val bigDecimalOperations: NumericOps[BigDecimal] =
@@ -100,7 +114,8 @@ object NumericSpec extends DefaultRunnableSpec {
         division = _ / _,
         isZero = _ == 0,
         log = (x, y) => Math.log(x.doubleValue) / Math.log(y.doubleValue),
-        root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble)
+        root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble),
+        abs = x => Math.abs(x.doubleValue)
       )
 
     val longOperations: NumericOps[Long] =
@@ -111,7 +126,8 @@ object NumericSpec extends DefaultRunnableSpec {
         division = _ / _,
         isZero = _ == 0,
         log = (x, y) => (Math.log(x.toDouble) / Math.log(y.toDouble)).toLong,
-        root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toLong
+        root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toLong,
+        abs = x => Math.abs(x)
       )
 
     val shortOperations: NumericOps[Short] =
@@ -122,7 +138,8 @@ object NumericSpec extends DefaultRunnableSpec {
         division = (x, y) => (x / y).toShort,
         isZero = _ == 0,
         log = (x, y) => (Math.log(x.toDouble) / Math.log(y.toDouble)).toShort,
-        root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toShort
+        root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toShort,
+        abs = x => Math.abs(x).toShort
       )
 
     val doubleOperations: NumericOps[Double] = NumericOps[Double](
@@ -132,7 +149,8 @@ object NumericSpec extends DefaultRunnableSpec {
       division = _ / _,
       isZero = _ == 0,
       log = (x, y) => Math.log(x) / Math.log(y),
-      root = (x, y) => Math.pow(x, 1 / y)
+      root = (x, y) => Math.pow(x, 1 / y),
+      abs = x => Math.abs(x)
     )
 
     val floatOperations: NumericOps[Float] = NumericOps[Float](
@@ -142,7 +160,8 @@ object NumericSpec extends DefaultRunnableSpec {
       division = _ / _,
       isZero = _ == 0,
       log = (x, y) => (Math.log(x.toDouble) / Math.log(y.toDouble)).toFloat,
-      root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toFloat
+      root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toFloat,
+      abs = x => Math.abs(x)
     )
   }
 }

--- a/zio-flow/shared/src/test/scala/zio/flow/NumericSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/NumericSpec.scala
@@ -33,7 +33,8 @@ object NumericSpec extends DefaultRunnableSpec {
       testOp[R, A]("Log", gen, gen)(_ log _)(ops.log),
       testOp[R, A]("Root", gen, gen)(_ root _)(ops.root),
       testOp[R, A]("Absolute", gen)(_.abs)(ops.abs),
-      testOp[R, A]("Minimum", gen, gen)(_ + _)(ops.min)
+      testOp[R, A]("Minimum", gen, gen)(_ + _)(ops.min),
+      testOp[R, A]("Maximum", gen, gen)(_ + _)(ops.max)
     )
 
   // TODO: BigDecimal fails Log/Root specs.
@@ -48,7 +49,8 @@ object NumericSpec extends DefaultRunnableSpec {
       ) @@ TestAspect.exceptScala211 @@ TestAspect.exceptScala212,
       testOp[R, A]("Multiplication", gen, gen)(_ * _)(ops.multiplication),
       testOp[R, A]("Division", gen, gen.filterNot(ops.isZero))(_ / _)(ops.division),
-      testOp[R, A]("Absolute", gen)(_.abs)(ops.abs)
+      testOp[R, A]("Absolute", gen)(_.abs)(ops.abs),
+      testOp[R, A]("Minimum", gen, gen)(_ + _)(ops.min)
 //      testOp[R, A]("Log", gen, gen)(_ log _)(ops.log),
 //      testOp[R, A]("Root", gen, gen)(_ root _)(ops.root)
     )
@@ -80,7 +82,8 @@ object NumericSpec extends DefaultRunnableSpec {
     log: (A, A) => A,
     root: (A, A) => A,
     abs: A => A,
-    min: (A, A) => A
+    min: (A, A) => A,
+    max: (A, A) => A
   )
 
   private object Operations {
@@ -94,7 +97,8 @@ object NumericSpec extends DefaultRunnableSpec {
         log = (x, y) => (Math.log(x.toDouble) / Math.log(y.toDouble)).toInt,
         root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toInt,
         abs = x => Math.abs(x),
-        min = Math.min
+        min = Math.min,
+        max = Math.max
       )
 
     val bigIntOperations: NumericOps[BigInt] =
@@ -107,7 +111,8 @@ object NumericSpec extends DefaultRunnableSpec {
         log = (x, y) => (Math.log(x.doubleValue) / Math.log(y.doubleValue)).toInt,
         root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toInt,
         abs = x => Math.abs(x.doubleValue).toInt,
-        min = (x, y) => Math.min(x.doubleValue, y.doubleValue).toInt
+        min = (x, y) => Math.min(x.doubleValue, y.doubleValue).toInt,
+        max = (x, y) => Math.max(x.doubleValue, y.doubleValue).toInt
       )
 
     val bigDecimalOperations: NumericOps[BigDecimal] =
@@ -120,7 +125,8 @@ object NumericSpec extends DefaultRunnableSpec {
         log = (x, y) => Math.log(x.doubleValue) / Math.log(y.doubleValue),
         root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble),
         abs = x => Math.abs(x.doubleValue),
-        min = (x, y) => Math.min(x.doubleValue, y.doubleValue)
+        min = (x, y) => Math.min(x.doubleValue, y.doubleValue),
+        max = (x, y) => Math.max(x.doubleValue, y.doubleValue)
       )
 
     val longOperations: NumericOps[Long] =
@@ -133,7 +139,8 @@ object NumericSpec extends DefaultRunnableSpec {
         log = (x, y) => (Math.log(x.toDouble) / Math.log(y.toDouble)).toLong,
         root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toLong,
         abs = x => Math.abs(x),
-        min = Math.min
+        min = Math.min,
+        max = Math.max
       )
 
     val shortOperations: NumericOps[Short] =
@@ -146,7 +153,8 @@ object NumericSpec extends DefaultRunnableSpec {
         log = (x, y) => (Math.log(x.toDouble) / Math.log(y.toDouble)).toShort,
         root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toShort,
         abs = x => Math.abs(x).toShort,
-        min = (x, y) => Math.min(x.toDouble, y.toDouble).toShort
+        min = (x, y) => Math.min(x.toDouble, y.toDouble).toShort,
+        max = (x, y) => Math.max(x.toDouble, y.toDouble).toShort
       )
 
     val doubleOperations: NumericOps[Double] = NumericOps[Double](
@@ -158,7 +166,8 @@ object NumericSpec extends DefaultRunnableSpec {
       log = (x, y) => Math.log(x) / Math.log(y),
       root = (x, y) => Math.pow(x, 1 / y),
       abs = x => Math.abs(x),
-      min = Math.min
+      min = Math.min,
+      max = Math.max
     )
 
     val floatOperations: NumericOps[Float] = NumericOps[Float](
@@ -170,7 +179,8 @@ object NumericSpec extends DefaultRunnableSpec {
       log = (x, y) => (Math.log(x.toDouble) / Math.log(y.toDouble)).toFloat,
       root = (x, y) => Math.pow(x.toDouble, 1 / y.toDouble).toFloat,
       abs = x => Math.abs(x),
-      min = Math.min
+      min = Math.min,
+      max = Math.max
     )
   }
 }


### PR DESCRIPTION
Add `abs`, `min`, `max`, `floor`, `ceil`, `round` extension methods on Remote[Numeric] 

see #78