### PR TITLE
Remote for Tuple3, Tuple4 and Tuple5

### DIFF
--- a/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
@@ -372,10 +372,12 @@ object Remote {
         case Right(schemaAndValue) =>
           unaryEvalWithSchema(tuple)(
             t => t._2,
-            remoteT => SecondOf3(remoteT),
-            schemaOf3(schemaAndValue).left
-              .asInstanceOf[Schema.Tuple[A, B]]
-              .right
+            remoteT => SecondOf3(remoteT), {
+              println(schemaAndValue.schema)
+              schemaOf3(schemaAndValue).left
+                .asInstanceOf[Schema.Tuple[A, B]]
+                .right
+            }
           )
       }
     }
@@ -406,12 +408,14 @@ object Remote {
         case Right(schemaAndValue) =>
           unaryEvalWithSchema(tuple)(
             t => t._1,
-            remoteT => FirstOf4(remoteT),
-            schemaOf4(schemaAndValue).left
-              .asInstanceOf[Schema.Tuple[(A, B), C]]
-              .left
-              .asInstanceOf[Schema.Tuple[A, B]]
-              .left
+            remoteT => FirstOf4(remoteT), {
+              println(schemaAndValue.schema)
+              schemaOf4(schemaAndValue).left
+                .asInstanceOf[Schema.Tuple[(A, B), C]]
+                .left
+                .asInstanceOf[Schema.Tuple[A, B]]
+                .left
+            }
           )
       }
     }
@@ -910,6 +914,21 @@ object Remote {
 
         case (Second(tuple1), Second(tuple2)) =>
           loop(tuple1, tuple2)
+
+        case (FirstOf3(tuple1), FirstOf3(tuple2))   => loop(tuple1, tuple2)
+        case (SecondOf3(tuple1), SecondOf3(tuple2)) => loop(tuple1, tuple2)
+        case (ThirdOf3(tuple1), ThirdOf3(tuple2))   => loop(tuple1, tuple2)
+
+        case (FirstOf4(tuple1), FirstOf4(tuple2))   => loop(tuple1, tuple2)
+        case (SecondOf4(tuple1), SecondOf4(tuple2)) => loop(tuple1, tuple2)
+        case (ThirdOf4(tuple1), ThirdOf4(tuple2))   => loop(tuple1, tuple2)
+        case (FourthOf4(tuple1), FourthOf4(tuple2)) => loop(tuple1, tuple2)
+
+        case (FirstOf5(tuple1), FirstOf5(tuple2))   => loop(tuple1, tuple2)
+        case (SecondOf5(tuple1), SecondOf5(tuple2)) => loop(tuple1, tuple2)
+        case (ThirdOf5(tuple1), ThirdOf5(tuple2))   => loop(tuple1, tuple2)
+        case (FourthOf5(tuple1), FourthOf5(tuple2)) => loop(tuple1, tuple2)
+        case (FifthOf5(tuple1), FifthOf5(tuple2))   => loop(tuple1, tuple2)
 
         case (Branch(predicate1, ifTrue1, ifFalse1), Branch(predicate2, ifTrue2, ifFalse2)) =>
           loop(predicate1, predicate2) &&

--- a/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
@@ -357,7 +357,9 @@ object Remote {
           unaryEvalWithSchema(tuple)(
             t => t._1,
             remoteT => FirstOf3(remoteT),
-            asSchemaOf2(schemaOf3(schemaAndValue).left).left
+            schemaOf3(schemaAndValue).left
+              .asInstanceOf[Schema.Tuple[A, B]]
+              .left
           )
       }
     }
@@ -373,7 +375,9 @@ object Remote {
           unaryEvalWithSchema(tuple)(
             t => t._2,
             remoteT => SecondOf3(remoteT),
-            schemaOf3(schemaAndValue).left.asInstanceOf[Schema.Tuple[A, B]].right
+            schemaOf3(schemaAndValue).left
+              .asInstanceOf[Schema.Tuple[A, B]]
+              .right
           )
       }
     }
@@ -444,7 +448,9 @@ object Remote {
           unaryEvalWithSchema(tuple)(
             t => t._3,
             remoteT => ThirdOf4(remoteT),
-            schemaOf4(schemaAndValue).left.asInstanceOf[Schema.Tuple[(A, B), C]].right
+            schemaOf4(schemaAndValue).left
+              .asInstanceOf[Schema.Tuple[(A, B), C]]
+              .right
           )
       }
     }
@@ -537,7 +543,9 @@ object Remote {
           unaryEvalWithSchema(tuple)(
             t => t._4,
             remoteT => FourthOf5(remoteT),
-            schemaOf5(schemaAndValue).left.asInstanceOf[Schema.Tuple[((A, B), C), D]].right
+            schemaOf5(schemaAndValue).left
+              .asInstanceOf[Schema.Tuple[((A, B), C), D]]
+              .right
           )
       }
     }

--- a/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
@@ -325,8 +325,6 @@ object Remote {
     }
   }
 
-  private def asSchemaOf2[A, B](schema: Schema[(A, B)]): Schema.Tuple[A, B] = schema.asInstanceOf[Schema.Tuple[A, B]]
-
   private def asSchemaOf3[A, B, C](schema: Schema[((A, B), C)]): Schema.Tuple[(A, B), C] =
     schema.asInstanceOf[Schema.Tuple[(A, B), C]]
 

--- a/zio-flow/shared/src/main/scala/zio/flow/RemoteTupleSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/RemoteTupleSyntax.scala
@@ -6,14 +6,22 @@ class RemoteTuple2Syntax[A, B](val self: Remote[(A, B)]) {
 }
 
 class RemoteTuple3Syntax[A, B, C](val self: Remote[(A, B, C)]) {
-  def _1: Remote[A] = ???
-  def _2: Remote[B] = ???
-  def _3: Remote[C] = ???
+  def _1: Remote[A] = Remote.FirstOf3(self)
+  def _2: Remote[B] = Remote.SecondOf3(self)
+  def _3: Remote[C] = Remote.ThirdOf3(self)
 }
 
 class RemoteTuple4Syntax[A, B, C, D](val self: Remote[(A, B, C, D)]) {
-  def _1: Remote[A] = ???
-  def _2: Remote[B] = ???
-  def _3: Remote[C] = ???
-  def _4: Remote[D] = ???
+  def _1: Remote[A] = Remote.FirstOf4(self)
+  def _2: Remote[B] = Remote.SecondOf4(self)
+  def _3: Remote[C] = Remote.ThirdOf4(self)
+  def _4: Remote[D] = Remote.FourthOf4(self)
+}
+
+class RemoteTuple5Syntax[A, B, C, D, E](val self: Remote[(A, B, C, D, E)]) {
+  def _1: Remote[A] = Remote.FirstOf5(self)
+  def _2: Remote[B] = Remote.SecondOf5(self)
+  def _3: Remote[C] = Remote.ThirdOf5(self)
+  def _4: Remote[D] = Remote.FourthOf5(self)
+  def _5: Remote[E] = Remote.FifthOf5(self)
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/package.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/package.scala
@@ -49,6 +49,9 @@ package object flow {
   implicit def RemoteTuple4[A, B, C, D](remote: Remote[(A, B, C, D)]): RemoteTuple4Syntax[A, B, C, D] =
     new RemoteTuple4Syntax(remote)
 
+  implicit def RemoteTuple5[A, B, C, D, E](remote: Remote[(A, B, C, D, E)]): RemoteTuple5Syntax[A, B, C, D, E] =
+    new RemoteTuple5Syntax(remote)
+
   implicit def RemoteList[A](remote: Remote[List[A]]): RemoteListSyntax[A] = new RemoteListSyntax[A](remote)
 
   implicit def RemoteOption[A](remote: Remote[Option[A]]): RemoteOptionSyntax[A] = new RemoteOptionSyntax[A](remote)

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteTupleSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteTupleSpec.scala
@@ -21,7 +21,7 @@ object RemoteTupleSpec extends DefaultRunnableSpec {
           tuple3._2 <-> "A",
           tuple3._3 <-> true
         )
-      } @@ TestAspect.ignore,
+      },
       test("Tuple4") {
         val tuple4 = Remote((1, "A", true, 10.5))
         BoolAlgebra.all(
@@ -30,7 +30,17 @@ object RemoteTupleSpec extends DefaultRunnableSpec {
           tuple4._3 <-> true,
           tuple4._4 <-> 10.5
         )
-      } @@ TestAspect.ignore
+      },
+      test("Tuple5") {
+        val tuple5 = Remote((1, "A", true, 10.5, "X"))
+        BoolAlgebra.all(
+          tuple5._1 <-> 1,
+          tuple5._2 <-> "A",
+          tuple5._3 <-> true,
+          tuple5._4 <-> 10.5,
+          tuple5._5 <-> "X"
+        )
+      }
     )
 
 }


### PR DESCRIPTION
Make use of `Remote` for Tuples with arity 3, 4 and 5 more convenient by providing accessors for all members of a particular tuple (`_1`, `_2`, `_3`, `_4`, `_5`).

`zio-schema`s `Schema` does support `Tuple`s with arity larger than 2 by wrapping them in a `Transform`, therefore at first this layer should be "unwrapped", following with a combination of `left`s with an optional `right` at the end to navigate the structure of nested Tuples to find the wanted member - be it  `_1`, `_2`, `_3`, `_4`, `_5`.

example of a schema for `Remote((1, "A", true, 10.5))`


```
Transform(
  Tuple(
    Tuple(
      Tuple(Primitive(int),Primitive(string)),
      Primitive(boolean)
    ),
    Primitive(double)
  )
)
```