### PR TITLE
Remote Optics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,8 @@ lazy val zioFlow = crossProject(JSPlatform, JVMPlatform)
       "dev.zio" %% "zio-test"              % zioVersion % "test",
       "dev.zio" %% "zio-test-sbt"          % zioVersion % "test",
       "dev.zio" %% "zio-schema"            % zioSchemaVersion,
-      "dev.zio" %% "zio-schema-derivation" % zioSchemaVersion
+      "dev.zio" %% "zio-schema-derivation" % zioSchemaVersion,
+      "dev.zio" %% "zio-schema-optics"     % zioSchemaVersion
     )
   )
   .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/Remote.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/Remote.scala
@@ -930,48 +930,48 @@ object Remote {
   final case class LensGet[S, A](whole: Remote[S], lens: RemoteLens[S, A]) extends Remote[A] {
     def evalWithSchema: Either[Remote[A], SchemaAndValue[A]] =
       whole.evalWithSchema match {
-        case Right(SchemaAndValue(schema, whole)) => Right(SchemaAndValue(lens.schemaPiece, lens.unsafeGet(whole)))
-        case _                                    => Left(self)
+        case Right(SchemaAndValue(_, whole)) => Right(SchemaAndValue(lens.schemaPiece, lens.unsafeGet(whole)))
+        case _                               => Left(self)
       }
   }
 
   final case class LensSet[S, A](whole: Remote[S], piece: Remote[A], lens: RemoteLens[S, A]) extends Remote[S] {
     def evalWithSchema: Either[Remote[S], SchemaAndValue[S]] =
       whole.evalWithSchema match {
-        case Right(SchemaAndValue(schemaWhole, whole)) =>
+        case Right(SchemaAndValue(_, whole)) =>
           piece.evalWithSchema match {
-            case Right(SchemaAndValue(schemaPiece, piece)) =>
+            case Right(SchemaAndValue(_, piece)) =>
               val newValue = lens.unsafeSet(piece)(whole)
               Right(SchemaAndValue(lens.schemaWhole, newValue))
-            case _                                         => Left(self)
+            case _                               => Left(self)
           }
-        case _                                         => Left(self)
+        case _                               => Left(self)
       }
   }
 
   final case class PrismGet[S, A](whole: Remote[S], prism: RemotePrism[S, A]) extends Remote[Option[A]] {
     def evalWithSchema: Either[Remote[Option[A]], SchemaAndValue[Option[A]]] =
       whole.evalWithSchema match {
-        case Right(SchemaAndValue(schema, whole)) =>
+        case Right(SchemaAndValue(_, whole)) =>
           Right(SchemaAndValue(Schema.option(prism.schemaPiece), prism.unsafeGet(whole)))
-        case _                                    => Left(self)
+        case _                               => Left(self)
       }
   }
 
   final case class PrismSet[S, A](piece: Remote[A], prism: RemotePrism[S, A]) extends Remote[S] {
     def evalWithSchema: Either[Remote[S], SchemaAndValue[S]] =
       piece.evalWithSchema match {
-        case Right(SchemaAndValue(schema, piece)) => Right(SchemaAndValue(prism.schemaWhole, prism.unsafeSet(piece)))
-        case _                                    => Left(self)
+        case Right(SchemaAndValue(_, piece)) => Right(SchemaAndValue(prism.schemaWhole, prism.unsafeSet(piece)))
+        case _                               => Left(self)
       }
   }
 
   final case class TraversalGet[S, A](whole: Remote[S], traversal: RemoteTraversal[S, A]) extends Remote[Chunk[A]] {
     def evalWithSchema: Either[Remote[Chunk[A]], SchemaAndValue[Chunk[A]]] =
       whole.evalWithSchema match {
-        case Right(SchemaAndValue(schema, whole)) =>
+        case Right(SchemaAndValue(_, whole)) =>
           Right(SchemaAndValue(Schema.chunk(traversal.schemaPiece), traversal.unsafeGet(whole)))
-        case _                                    => Left(self)
+        case _                               => Left(self)
       }
   }
 
@@ -979,14 +979,14 @@ object Remote {
       extends Remote[S] {
     def evalWithSchema: Either[Remote[S], SchemaAndValue[S]] =
       whole.evalWithSchema match {
-        case Right(SchemaAndValue(schema, whole)) =>
+        case Right(SchemaAndValue(_, whole)) =>
           piece.evalWithSchema match {
-            case Right(SchemaAndValue(schemaPiece, piece)) =>
+            case Right(SchemaAndValue(_, piece)) =>
               val newValue = traversal.unsafeSet(whole)(piece)
               Right(SchemaAndValue(traversal.schemaWhole, newValue))
-            case _                                         => Left(self)
+            case _                               => Left(self)
           }
-        case _                                    => Left(self)
+        case _                               => Left(self)
       }
   }
 

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteAccessorBuilder.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteAccessorBuilder.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019-2021 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.flow.remote
+
+import zio.schema._
+
+/**
+ * A `RemoteAccessorBuilder` knows how to build accessors for remote
+ * descriptions of sum and product types. This allows easily getting or
+ * setting fields of user defined product types or fields of user defined sum
+ * types.
+ */
+object RemoteAccessorBuilder extends AccessorBuilder {
+
+  type Lens[S, A]      = RemoteLens[S, A]
+  type Prism[S, A]     = RemotePrism[S, A]
+  type Traversal[S, A] = RemoteTraversal[S, A]
+
+  def makeLens[S, A](product: Schema.Record[S], term: Schema.Field[A]): Lens[S, A] =
+    RemoteLens.unsafeMake(product, term)
+
+  def makePrism[S, A](sum: Schema.Enum[S], term: Schema.Case[A, S]): Prism[S, A] =
+    RemotePrism.unsafeMake(sum, term)
+
+  def makeTraversal[S, A](collection: Schema.Collection[S, A], element: Schema[A]): Traversal[S, A] =
+    RemoteTraversal.unsafeMake(collection, element)
+}

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteLens.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteLens.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019-2021 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.flow.remote
+
+import zio.schema._
+
+import scala.collection.immutable.ListMap
+
+/**
+ * A `RemoteLens[S, A]` knows how to access a field `A` of a product type `S`
+ * in the context of a remote value.
+ */
+sealed trait RemoteLens[S, A] { self =>
+
+  /**
+   * The schema describing the structure of the type `A` being accessed by this
+   * lens.
+   */
+  def schemaPiece: Schema[A]
+
+  /**
+   * The schema describing the structure of the type `S` being access by this
+   * lens.
+   */
+  def schemaWhole: Schema[S]
+
+  /**
+   * Gets the value of the field of the specified product type.
+   */
+  def get(s: Remote[S]): Remote[A] =
+    Remote.LensGet(s, self)
+
+  /**
+   * Sets the field of the specified product type to the specified value.
+   */
+  def set(s: Remote[S])(a: Remote[A]): Remote[S] =
+    Remote.LensSet(s, a, self)
+
+  /**
+   * Updates the value of the field of the specified product type with the
+   * specified function.
+   */
+  def update(s: Remote[S])(f: Remote[A] => Remote[A]): Remote[S] =
+    set(s)(f(get(s)))
+
+  /**
+   * Gets the value of the field of the specified product type
+   * outside the context of a remote value.
+   */
+  private[remote] def unsafeGet(s: S): A
+
+  /**
+   * Sets the field of the specified product type to the specified value
+   * outside the context of a remote value.
+   */
+  private[remote] def unsafeSet(a: A)(s: S): S
+}
+
+object RemoteLens {
+
+  /**
+   * Unsafely constructs a remote lens from a description of the structure of
+   * the product type and field. The caller is responsible for ensuring that
+   * the field exists in the product type.
+   */
+  private[remote] def unsafeMake[S, A](product: Schema.Record[S], field: Schema.Field[A]): RemoteLens[S, A] =
+    Primitive(product, field)
+
+  /**
+   * A remote lens formed directly from the structure of a product type and a
+   * field of that product type.
+   */
+  private final case class Primitive[S, A](product: Schema.Record[S], field: Schema.Field[A]) extends RemoteLens[S, A] {
+    val schemaPiece: Schema[A] = field.schema
+    val schemaWhole: Schema[S] = product
+
+    def unsafeGet(s: S): A =
+      product.toDynamic(s) match {
+        case DynamicValue.Record(values) =>
+          values
+            .get(field.label)
+            .map { dynamicField =>
+              field.schema.fromDynamic(dynamicField) match {
+                case Left(error)  => throw new IllegalStateException(error)
+                case Right(value) => value
+              }
+            }
+            .getOrElse(throw new IllegalStateException(s"No field found with label ${field.label}"))
+        case _                           => throw new IllegalStateException("Unexpected dynamic value for product type")
+      }
+
+    def unsafeSet(a: A)(s: S): S =
+      product.toDynamic(s) match {
+        case DynamicValue.Record(values) =>
+          val updated = spliceRecord(values, field.label, field.label -> field.schema.toDynamic(a))
+          product.fromDynamic(DynamicValue.Record(updated)) match {
+            case Left(error)  => throw new IllegalStateException(error)
+            case Right(value) => value
+          }
+        case _                           => throw new IllegalStateException("Unexpected dynamic value for product type")
+      }
+
+    def spliceRecord(
+      fields: ListMap[String, DynamicValue],
+      label: String,
+      splicedField: (String, DynamicValue)
+    ): ListMap[String, DynamicValue] =
+      fields.foldLeft[ListMap[String, DynamicValue]](ListMap.empty) {
+        case (acc, (nextLabel, _)) if nextLabel == label => acc + splicedField
+        case (acc, nextField)                            => acc + nextField
+      }
+  }
+}

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemotePrism.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemotePrism.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019-2021 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.flow.remote
+
+import zio.schema._
+
+/**
+ * A `RemotePrism[S, A]` knows how to access a case `A` of a sum type `S` in
+ * the context of a remote value.
+ */
+sealed trait RemotePrism[S, A] { self =>
+
+  /**
+   * The schema describing the structure of the type `A` being accessed by this
+   * prism.
+   */
+  def schemaPiece: Schema[A]
+
+  /**
+   * The schema describing the structure of the type `S` being access by this
+   * prism.
+   */
+  def schemaWhole: Schema[S]
+
+  /**
+   * Gets the case of the specified sum type if it exists or returns
+   * `None` otherwise.
+   */
+  def get(s: Remote[S]): Remote[Option[A]] =
+    Remote.PrismGet(s, self)
+
+  /**
+   * Views the specified case as an instance of the sum type.
+   */
+  def set(a: Remote[A]): Remote[S] =
+    Remote.PrismSet(a, self)
+
+  /**
+   * Gets the case of the specified sum type if it exists or returns
+   * `None` otherwise outside the context of a remote value.
+   */
+  private[remote] def unsafeGet(s: S): Option[A]
+
+  /**
+   * Views the specified case as an instance of the sum type outside the
+   * context of a remote value.
+   */
+  private[remote] def unsafeSet(a: A): S
+}
+
+object RemotePrism {
+
+  /**
+   * Unsafely constructs a remote prism from a description of the structure of
+   * the sum type and case. The caller is responsible for ensuring that
+   * the case is one of the cases of the sum type.
+   */
+  private[remote] def unsafeMake[S, A](product: Schema.Enum[S], term: Schema.Case[A, S]): RemotePrism[S, A] =
+    Primitive(product, term)
+
+  /**
+   * A remote prism formed directly from the structure of a sum type and a case
+   * of that sum type.
+   */
+  private final case class Primitive[S, A](product: Schema.Enum[S], term: Schema.Case[A, S]) extends RemotePrism[S, A] {
+    val schemaPiece = term.codec
+    val schemaWhole = product
+
+    def unsafeGet(s: S): Option[A] =
+      term.deconstruct(s)
+
+    def unsafeSet(a: A): S =
+      a.asInstanceOf[S]
+  }
+}

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteTraversal.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteTraversal.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019-2021 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.flow.remote
+
+import zio.{ Chunk, ChunkBuilder }
+import zio.schema._
+
+/**
+ * A `RemoteTraversal[S, A]` knows how to access zero or more elements of a
+ * collection type `S` in the context of a remote value.
+ */
+sealed trait RemoteTraversal[S, A] { self =>
+
+  /**
+   * The schema describing the structure of the type `A` being accessed by this
+   * traversal.
+   */
+  def schemaPiece: Schema[A]
+
+  /**
+   * The schema describing the structure of the type `S` being access by this
+   * lens.
+   */
+  def schemaWhole: Schema[S]
+
+  /**
+   * Gets the elements of the specified collection type.
+   */
+  def get(s: Remote[S]): Remote[Chunk[A]] =
+    Remote.TraversalGet(s, self)
+
+  /**
+   * Sets the elements of the specified collection type to the specified
+   * values.
+   */
+  def set(s: Remote[S])(as: Remote[Chunk[A]]): Remote[S] =
+    Remote.TraversalSet(s, as, self)
+
+  /**
+   * Updates the values of the elements of the specified collection type with
+   * the specified function.
+   */
+  def update(s: Remote[S])(f: Remote[Chunk[A]] => Remote[Chunk[A]]): Remote[S] =
+    set(s)(f(get(s)))
+
+  /**
+   * Gets the elements of the specified collection type outside the context of
+   * a remote value.
+   */
+  private[remote] def unsafeGet(s: S): Chunk[A]
+
+  /**
+   * Sets the elements of the specified collection type to the specified
+   * values outside the context of a remote value.
+   */
+  private[remote] def unsafeSet(s: S)(as: Chunk[A]): S
+}
+
+object RemoteTraversal {
+
+  /**
+   * Unsafely constructs a remote traversal from a description of the structure
+   * of the collection and element types. The caller is responsible for
+   * ensuring that the element type corresponds to the collection type.
+   */
+  def unsafeMake[S, A](collection: Schema.Collection[S, A], element: Schema[A]): RemoteTraversal[S, A] =
+    Primitive(collection, element)
+
+  /**
+   * A remote lens formed directly from the structure of a collection type and
+   * element type.
+   */
+  private final case class Primitive[S, A](collection: Schema.Collection[S, A], element: Schema[A])
+      extends RemoteTraversal[S, A] {
+    val schemaPiece: Schema[A] = element
+    val schemaWhole: Schema[S] = collection
+
+    def unsafeGet(s: S): Chunk[A] =
+      (collection.asInstanceOf[Schema.Collection[_, _]]) match {
+        case sequence @ Schema.Sequence(_, _, _, _) =>
+          sequence.asInstanceOf[Schema.Sequence[S, A]].toChunk(s)
+        case Schema.MapSchema(_, _, _)              =>
+          Chunk.fromIterable(s.asInstanceOf[Map[_, _]]).asInstanceOf[Chunk[A]]
+      }
+
+    def unsafeSet(s: S)(as: Chunk[A]): S =
+      (collection.asInstanceOf[Schema.Collection[_, _]]) match {
+        case sequence @ Schema.Sequence(_, _, _, _) =>
+          val builder       = ChunkBuilder.make[A]()
+          val leftIterator  = sequence.asInstanceOf[Schema.Sequence[S, A]].toChunk(s).iterator
+          val rightIterator = as.iterator
+          while (leftIterator.hasNext && rightIterator.hasNext) {
+            val _ = leftIterator.next()
+            builder += rightIterator.next()
+          }
+          while (leftIterator.hasNext)
+            builder += leftIterator.next()
+          sequence.asInstanceOf[Schema.Sequence[S, A]].fromChunk(builder.result())
+        case Schema.MapSchema(_, _, _)              =>
+          (s.asInstanceOf[Map[_, _]] ++ as).asInstanceOf[S]
+      }
+  }
+}

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteOpticsSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteOpticsSpec.scala
@@ -1,0 +1,69 @@
+package zio.flow
+
+import zio.flow.remote._
+import zio.flow.utils.RemoteAssertionSyntax.RemoteAssertionOps
+import zio.random._
+import zio.schema._
+import zio.test._
+
+object RemoteOpticsSpec extends DefaultRunnableSpec {
+
+  final case class Person(name: String, age: Int)
+
+  object Person {
+    implicit val schema = DeriveSchema.gen[Person]
+    val (name, age)     = Remote.makeAccessors[Person]
+  }
+
+  val genPerson: Gen[Random with Sized, Person] =
+    for {
+      name <- Gen.anyString
+      age  <- Gen.anyInt
+    } yield Person(name, age)
+
+  sealed trait Color { self =>
+    def blue: Option[Blue.type] =
+      self match {
+        case Blue => Some(Blue)
+        case _    => None
+      }
+  }
+
+  case object Blue  extends Color
+  case object Green extends Color
+  case object Red   extends Color
+
+  object Color {
+    implicit val schema     = DeriveSchema.gen[Color]
+    implicit val blueSchema = DeriveSchema.gen[Blue.type]
+    val (blue, green, red)  = Remote.makeAccessors[Color]
+  }
+
+  val genColor: Gen[Random with Sized, Color] =
+    Gen.elements(Red, Green, Blue)
+
+  def spec = suite("RemoteOpticsSpec")(
+    suite("RemoteLens")(
+      testM("get") {
+        check(genPerson) { person =>
+          Person.age.get(Remote(person)) <-> person.age
+        }
+      },
+      testM("set") {
+        check(genPerson, Gen.anyInt) { (person, age) =>
+          Person.age.set(person)(age) <-> person.copy(age = age)
+        }
+      }
+    ),
+    suite("RemotePrism")(
+      testM("get") {
+        check(genColor) { color =>
+          Color.blue.get(Remote(color)) <-> color.blue
+        }
+      },
+      test("set") {
+        Color.blue.set(Remote(Blue)) <-> Blue
+      }
+    )
+  )
+}


### PR DESCRIPTION
Uses reified optics functionality from ZIO Schema to implement accessors for user defined data types.

```scala
final case class Person(name: String, age: Int)

object Person {
  implicit val schema = DeriveSchema.gen[Person]
  val (name, age)     = Remote.makeAccessors[Person]
}

val person: Remote[Person] = Remote(Person("Jane Doe", 42))

Person.age.update(person)(_ + 1)
```