### PR TITLE
Don't Publish For Scala 2.11

### DIFF
--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -206,7 +206,7 @@ object BuildHelper {
 
   def stdSettings(prjName: String) = Seq(
     name                     := s"$prjName",
-    crossScalaVersions       := Seq(Scala211, Scala212, Scala213),
+    crossScalaVersions       := Seq(Scala212, Scala213),
     ThisBuild / scalaVersion := Scala213,
     scalacOptions            := stdOptions ++ extraOptions(scalaVersion.value, optimize = !isSnapshot.value),
     libraryDependencies ++= {


### PR DESCRIPTION
Publishing is currently failing because ZIO Schema isn't published for Scala 2.11. I think we can just drop support. We already don't test for it.