### PR TITLE
Fix for RemoteDurationSpec and RemoteInstantSpec

### DIFF
--- a/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
@@ -17,7 +17,7 @@
 package zio.flow
 
 import java.math.BigDecimal
-import java.time.temporal.{ChronoUnit, Temporal, TemporalAmount, TemporalField, TemporalUnit}
+import java.time.temporal.{ChronoUnit, Temporal, TemporalAmount, TemporalUnit}
 import java.time.{Clock, Duration, Instant}
 import scala.language.implicitConversions
 import zio.Chunk
@@ -905,7 +905,7 @@ object Remote {
   }
 
   final case class DurationFromBigDecimal(seconds: Remote[BigDecimal]) extends Remote[Duration] {
-    private val oneBillion = new BigDecimal(1000_000_000L)
+    private val oneBillion = new BigDecimal(1000000000L)
 
     override def evalWithSchema: Either[Remote[Duration], SchemaAndValue[Duration]] =
       unaryEval(seconds)(

--- a/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
@@ -850,18 +850,23 @@ object Remote {
         .map(SchemaAndValue(Schema[Int], _))
   }
 
-  final case class ToInstantPlusDuration(epoch: Remote[(Long, Int)], secsNanosDuration: Remote[(Long, Long)]) extends Remote[Instant] {
+  final case class ToInstantPlusDuration(epoch: Remote[(Long, Int)], duration: Remote[(Long, Long)])
+      extends Remote[Instant] {
     override def evalWithSchema: Either[Remote[Instant], SchemaAndValue[Instant]] =
-      binaryEval(epoch, secsNanosDuration)(
+      binaryEval(epoch, duration)(
         (epoch, duration) => Instant.ofEpochSecond(epoch._1, epoch._2).plusSeconds(duration._1).plusNanos(duration._2),
         (remoteE, remoteD) => ToInstantPlusDuration(remoteE, remoteD)
       ).map(SchemaAndValue(Schema[Instant], _))
   }
 
-  final case class ToInstantMinusDuration(epoch: Remote[(Long, Int)], secsNanosDuration: Remote[(Long, Long)]) extends Remote[Instant] {
+  final case class ToInstantMinusDuration(epoch: Remote[(Long, Int)], duration: Remote[(Long, Long)])
+      extends Remote[Instant] {
     override def evalWithSchema: Either[Remote[Instant], SchemaAndValue[Instant]] =
-      binaryEval(epoch, secsNanosDuration)(
-        (epoch, duration) => Instant.ofEpochSecond(epoch._1, epoch._2).minusSeconds(duration._1).minusNanos(duration._2),
+      binaryEval(epoch, duration)(
+        (
+          epoch,
+          duration
+        ) => Instant.ofEpochSecond(epoch._1, epoch._2).minusSeconds(duration._1).minusNanos(duration._2),
         (remoteE, remoteD) => ToInstantMinusDuration(remoteE, remoteD)
       ).map(SchemaAndValue(Schema[Instant], _))
   }
@@ -908,7 +913,8 @@ object Remote {
         .map(SchemaAndValue(Schema[Duration], _))
   }
 
-  final case class SecsNanosToPlusDuration(left: Remote[(Long, Long)], right: Remote[(Long, Long)]) extends Remote[Duration] {
+  final case class SecsNanosToPlusDuration(left: Remote[(Long, Long)], right: Remote[(Long, Long)])
+      extends Remote[Duration] {
     override def evalWithSchema: Either[Remote[Duration], SchemaAndValue[Duration]] =
       binaryEval(left, right)(
         (left, right) => Duration.ofSeconds(left._1, left._2).plus(Duration.ofSeconds(right._1, right._2)),
@@ -916,7 +922,8 @@ object Remote {
       ).map(SchemaAndValue(Schema[Duration], _))
   }
 
-  final case class SecsNanosToMinusDuration(left: Remote[(Long, Long)], right: Remote[(Long, Long)]) extends Remote[Duration] {
+  final case class SecsNanosToMinusDuration(left: Remote[(Long, Long)], right: Remote[(Long, Long)])
+      extends Remote[Duration] {
     override def evalWithSchema: Either[Remote[Duration], SchemaAndValue[Duration]] =
       binaryEval(left, right)(
         (left, right) => Duration.ofSeconds(left._1, left._2).minus(Duration.ofSeconds(right._1, right._2)),

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteDurationSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteDurationSyntax.scala
@@ -24,15 +24,18 @@ import java.time.temporal.{Temporal, TemporalAmount}
 class RemoteDurationSyntax(val self: Remote[Duration]) extends AnyVal {
 
   def plusDuration2(that: Remote[Duration]): Remote[Duration] =
-    Remote.ofSeconds(self.toSeconds + that.toSeconds)
+    secsNanosToPlusDuration(self.toSecsNanos, that.toSecsNanos)
 
   def minusDuration(that: Remote[Duration]): Remote[Duration] =
-    Remote.ofSeconds(self.toSeconds - that.toSeconds)
+    secsNanosToMinusDuration(self.toSecsNanos, that.toSecsNanos)
 
   def durationToLong: Remote[Long] =
     Remote.DurationToLong(self.widen[Duration])
 
   def toSeconds: Remote[Long] = self.durationToLong
+
+  def toSecsNanos: Remote[(Long, Long)] =
+    Remote.DurationToSecsNanos(self)
 
   def isZero: Remote[Boolean] = self.toSeconds === 0L && self.getNano === 0L
 
@@ -50,6 +53,11 @@ class RemoteDurationSyntax(val self: Remote[Duration]) extends AnyVal {
 
   def plusNanos(nanoToAdd: Remote[Long]): Remote[Duration] = plusDuration2(Remote.ofNanos(nanoToAdd))
 
+  private def secsNanosToPlusDuration(left: Remote[(Long, Long)], right: Remote[(Long, Long)]): Remote[Duration] =
+    Remote.SecsNanosToPlusDuration(left, right)
+
+  private def secsNanosToMinusDuration(left: Remote[(Long, Long)], right: Remote[(Long, Long)]): Remote[Duration] =
+    Remote.SecsNanosToMinusDuration(left, right)
 }
 
 object RemoteDuration {

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteDurationSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteDurationSyntax.scala
@@ -23,7 +23,7 @@ import java.time.temporal.{Temporal, TemporalAmount}
 
 class RemoteDurationSyntax(val self: Remote[Duration]) extends AnyVal {
 
-  def plusDuration2(that: Remote[Duration]): Remote[Duration] =
+  def plusDuration(that: Remote[Duration]): Remote[Duration] =
     secsNanosToPlusDuration(self.toSecsNanos, that.toSecsNanos)
 
   def minusDuration(that: Remote[Duration]): Remote[Duration] =
@@ -43,15 +43,15 @@ class RemoteDurationSyntax(val self: Remote[Duration]) extends AnyVal {
   def getSeconds: Remote[Long]    = Remote.DurationToSecsNanos(self.widen[Duration])._1
   def getNano: Remote[Long]       = Remote.DurationToSecsNanos(self.widen[Duration])._2
 
-  def plusDays(daysToAdd: Remote[Long]): Remote[Duration] = plusDuration2(Remote.ofDays(daysToAdd))
+  def plusDays(daysToAdd: Remote[Long]): Remote[Duration] = plusDuration(Remote.ofDays(daysToAdd))
 
-  def plusHours(hoursToAdd: Remote[Long]): Remote[Duration] = plusDuration2(Remote.ofHours(hoursToAdd))
+  def plusHours(hoursToAdd: Remote[Long]): Remote[Duration] = plusDuration(Remote.ofHours(hoursToAdd))
 
-  def plusMinutes(minsToAdd: Remote[Long]): Remote[Duration] = plusDuration2(Remote.ofMinutes(minsToAdd))
+  def plusMinutes(minsToAdd: Remote[Long]): Remote[Duration] = plusDuration(Remote.ofMinutes(minsToAdd))
 
-  def plusSeconds(secondsToAdd: Remote[Long]): Remote[Duration] = plusDuration2(Remote.ofSeconds(secondsToAdd))
+  def plusSeconds(secondsToAdd: Remote[Long]): Remote[Duration] = plusDuration(Remote.ofSeconds(secondsToAdd))
 
-  def plusNanos(nanoToAdd: Remote[Long]): Remote[Duration] = plusDuration2(Remote.ofNanos(nanoToAdd))
+  def plusNanos(nanoToAdd: Remote[Long]): Remote[Duration] = plusDuration(Remote.ofNanos(nanoToAdd))
 
   private def secsNanosToPlusDuration(left: Remote[(Long, Long)], right: Remote[(Long, Long)]): Remote[Duration] =
     Remote.SecsNanosToPlusDuration(left, right)

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteDurationSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteDurationSyntax.scala
@@ -19,54 +19,51 @@ package zio.flow.remote
 import zio.flow._
 
 import java.time.Duration
-import java.time.temporal.{Temporal, TemporalAmount}
+import java.time.temporal.{Temporal, TemporalAmount, TemporalUnit}
 
 class RemoteDurationSyntax(val self: Remote[Duration]) extends AnyVal {
 
-  def plusDuration(that: Remote[Duration]): Remote[Duration] =
-    secsNanosToPlusDuration(self.toSecsNanos, that.toSecsNanos)
+  def isZero: Remote[Boolean]     = self.getSeconds === 0L && self.getNano === 0L
+  def isNegative: Remote[Boolean] = self.getSeconds < 0L
+  def getSeconds: Remote[Long]    = Remote.DurationToLongs(self.widen[Duration])._1
+  def getNano: Remote[Long]       = Remote.DurationToLongs(self.widen[Duration])._2
 
-  def minusDuration(that: Remote[Duration]): Remote[Duration] =
-    secsNanosToMinusDuration(self.toSecsNanos, that.toSecsNanos)
+  def plus(that: Remote[Duration]): Remote[Duration] =
+    Remote.DurationPlusDuration(self, that)
 
-  def durationToLong: Remote[Long] =
-    Remote.DurationToLong(self.widen[Duration])
+  def plus(amountToAdd: Remote[Long], temporalUnit: Remote[TemporalUnit]): Remote[Duration] =
+    plus(Remote.DurationFromAmount(amountToAdd, temporalUnit))
 
-  def toSeconds: Remote[Long] = self.durationToLong
+  def plusDays(daysToAdd: Remote[Long]): Remote[Duration]       = plus(Remote.ofDays(daysToAdd))
+  def plusHours(hoursToAdd: Remote[Long]): Remote[Duration]     = plus(Remote.ofHours(hoursToAdd))
+  def plusMinutes(minutesToAdd: Remote[Long]): Remote[Duration] = plus(Remote.ofMinutes(minutesToAdd))
+  def plusSeconds(secondsToAdd: Remote[Long]): Remote[Duration] = plus(Remote.ofSeconds(secondsToAdd))
+  def plusNanos(nanoToAdd: Remote[Long]): Remote[Duration]      = plus(Remote.ofNanos(nanoToAdd))
 
-  def toSecsNanos: Remote[(Long, Long)] =
-    Remote.DurationToSecsNanos(self)
+  def minus(that: Remote[Duration]): Remote[Duration] =
+    Remote.DurationMinusDuration(self, that)
 
-  def isZero: Remote[Boolean] = self.toSeconds === 0L && self.getNano === 0L
+  def minus(amountToSubtract: Remote[Long], temporalUnit: Remote[TemporalUnit]): Remote[Duration] =
+    minus(Remote.DurationFromAmount(amountToSubtract, temporalUnit))
 
-  def isNegative: Remote[Boolean] = self.toSeconds < 0L
-  def getSeconds: Remote[Long]    = Remote.DurationToSecsNanos(self.widen[Duration])._1
-  def getNano: Remote[Long]       = Remote.DurationToSecsNanos(self.widen[Duration])._2
-
-  def plusDays(daysToAdd: Remote[Long]): Remote[Duration] = plusDuration(Remote.ofDays(daysToAdd))
-
-  def plusHours(hoursToAdd: Remote[Long]): Remote[Duration] = plusDuration(Remote.ofHours(hoursToAdd))
-
-  def plusMinutes(minsToAdd: Remote[Long]): Remote[Duration] = plusDuration(Remote.ofMinutes(minsToAdd))
-
-  def plusSeconds(secondsToAdd: Remote[Long]): Remote[Duration] = plusDuration(Remote.ofSeconds(secondsToAdd))
-
-  def plusNanos(nanoToAdd: Remote[Long]): Remote[Duration] = plusDuration(Remote.ofNanos(nanoToAdd))
-
-  private def secsNanosToPlusDuration(left: Remote[(Long, Long)], right: Remote[(Long, Long)]): Remote[Duration] =
-    Remote.SecsNanosToPlusDuration(left, right)
-
-  private def secsNanosToMinusDuration(left: Remote[(Long, Long)], right: Remote[(Long, Long)]): Remote[Duration] =
-    Remote.SecsNanosToMinusDuration(left, right)
+  def minusDays(daysToSubtract: Remote[Long]): Remote[Duration]       = minus(Remote.ofDays(daysToSubtract))
+  def minusHours(hoursToSubtract: Remote[Long]): Remote[Duration]     = minus(Remote.ofHours(hoursToSubtract))
+  def minusMinutes(minutesToSubtract: Remote[Long]): Remote[Duration] = minus(Remote.ofMinutes(minutesToSubtract))
+  def minusSeconds(secondsToSubtract: Remote[Long]): Remote[Duration] = minus(Remote.ofSeconds(secondsToSubtract))
+  def minusNanos(nanosToSubtract: Remote[Long]): Remote[Duration]     = minus(Remote.ofNanos(nanosToSubtract))
 }
 
 object RemoteDuration {
 
-  def from(amount: Remote[TemporalAmount]): Remote[Duration] = ???
+  def from(amount: Remote[TemporalAmount]): Remote[Duration] =
+    Remote.DurationFromTemporalAmount(amount)
 
-  def parse(charSequence: Remote[String]): Remote[Duration] = ???
+  def parse(charSequence: Remote[String]): Remote[Duration] =
+    Remote.DurationFromString(charSequence)
 
-  def create(seconds: Remote[BigDecimal]): Remote[Duration] = ???
+  def create(seconds: Remote[java.math.BigDecimal]): Remote[Duration] =
+    Remote.DurationFromBigDecimal(seconds)
 
-  def between(startInclusive: Remote[Temporal], endExclusive: Remote[Temporal]): Remote[Duration] = ???
+  def between(startInclusive: Remote[Temporal], endExclusive: Remote[Temporal]): Remote[Duration] =
+    Remote.DurationFromTemporals(startInclusive, endExclusive)
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteInstantSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteInstantSyntax.scala
@@ -33,14 +33,14 @@ class RemoteInstantSyntax(val self: Remote[Instant]) extends AnyVal {
     Remote.InstantToTuple(self)
 
   def plusDuration(duration: Remote[Duration]): Remote[Instant] = {
-    val durationSecsNanos = duration.toSecsNanos
+    val durationSecsNanos     = duration.toSecsNanos
     val instantEpochSecsNanos = toEpochSecsNanos
 
     Remote.ToInstantPlusDuration(instantEpochSecsNanos, durationSecsNanos)
   }
 
   def minusDuration(duration: Remote[Duration]): Remote[Instant] = {
-    val durationSecsNanos = duration.toSecsNanos
+    val durationSecsNanos     = duration.toSecsNanos
     val instantEpochSecsNanos = toEpochSecsNanos
 
     Remote.ToInstantMinusDuration(instantEpochSecsNanos, durationSecsNanos)

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteInstantSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteInstantSyntax.scala
@@ -29,20 +29,21 @@ class RemoteInstantSyntax(val self: Remote[Instant]) extends AnyVal {
   def getEpochSec: Remote[Long] =
     Remote.InstantToLong(self)
 
-  def plusDuration(duration: Remote[Duration]): Remote[Instant] = {
-    val longDuration = duration.toSeconds
-    val epochSecond  = getEpochSec
-    val total        = longDuration + epochSecond
+  def toEpochSecsNanos: Remote[(Long, Int)] =
+    Remote.InstantToTuple(self)
 
-    Remote.fromEpochSec(total)
+  def plusDuration(duration: Remote[Duration]): Remote[Instant] = {
+    val durationSecsNanos = duration.toSecsNanos
+    val instantEpochSecsNanos = toEpochSecsNanos
+
+    Remote.ToInstantPlusDuration(instantEpochSecsNanos, durationSecsNanos)
   }
 
   def minusDuration(duration: Remote[Duration]): Remote[Instant] = {
-    val longDuration = duration.toSeconds
-    val epochSecond  = getEpochSec
-    val total        = epochSecond - longDuration
+    val durationSecsNanos = duration.toSecsNanos
+    val instantEpochSecsNanos = toEpochSecsNanos
 
-    Remote.fromEpochSec(total)
+    Remote.ToInstantMinusDuration(instantEpochSecsNanos, durationSecsNanos)
   }
 
   def get(field: Remote[TemporalField]): Remote[Int] = Remote.TemporalFieldOfInstant(self, field)
@@ -54,13 +55,13 @@ class RemoteInstantSyntax(val self: Remote[Instant]) extends AnyVal {
     self.plusDuration(Remote.AmountToDuration(amountToAdd, unit))
 
   def plusSeconds(secondsToAdd: Remote[Long]): Remote[Instant] =
-    Remote.fromEpochSec(self.getEpochSec + secondsToAdd)
+    self.plusDuration(Remote.AmountToDuration(secondsToAdd, Remote(ChronoUnit.SECONDS)))
 
   def plusMillis(milliSecondsToAdd: Remote[Long]): Remote[Instant] =
-    self.plus(milliSecondsToAdd, ChronoUnit.MILLIS)
+    self.plusDuration(Remote.AmountToDuration(milliSecondsToAdd, Remote(ChronoUnit.MILLIS)))
 
   def plusNanos(nanoSecondsToAdd: Remote[Long]): Remote[Instant] =
-    self.plus(nanoSecondsToAdd, ChronoUnit.NANOS)
+    self.plusDuration(Remote.AmountToDuration(nanoSecondsToAdd, Remote(ChronoUnit.NANOS)))
 
   def minus(amountToSubtract: Remote[TemporalAmount]): Remote[Instant] =
     self.minusDuration(Remote.DurationFromTemporalAmount(amountToSubtract))
@@ -69,13 +70,13 @@ class RemoteInstantSyntax(val self: Remote[Instant]) extends AnyVal {
     self.minusDuration(Remote.AmountToDuration(amountToSubtract, unit))
 
   def minusSeconds(secondsToSubtract: Remote[Long]): Remote[Instant] =
-    Remote.fromEpochSec(self.getEpochSec - secondsToSubtract)
+    self.minusDuration(Remote.AmountToDuration(secondsToSubtract, Remote(ChronoUnit.SECONDS)))
 
   def minusNanos(nanosecondsToSubtract: Remote[Long]): Remote[Instant] =
-    self.minus(nanosecondsToSubtract, ChronoUnit.NANOS)
+    self.minusDuration(Remote.AmountToDuration(nanosecondsToSubtract, Remote(ChronoUnit.NANOS)))
 
   def minusMillis(milliSecondsToSubtract: Remote[Long]): Remote[Instant] =
-    self.minus(milliSecondsToSubtract, ChronoUnit.MILLIS)
+    self.minusDuration(Remote.AmountToDuration(milliSecondsToSubtract, Remote(ChronoUnit.MILLIS)))
 }
 
 object RemoteInstantSyntax {

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteInstantSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteInstantSyntax.scala
@@ -18,75 +18,58 @@ package zio.flow.remote
 
 import zio.flow._
 
-import java.time.temporal.{ChronoUnit, TemporalAmount, TemporalField, TemporalUnit}
+import java.time.temporal.{ChronoUnit, TemporalAmount, TemporalUnit}
 import java.time.{Clock, Duration, Instant}
 
 class RemoteInstantSyntax(val self: Remote[Instant]) extends AnyVal {
-  def isAfter(that: RemoteInstantSyntax): Remote[Boolean] = self.getEpochSec > that.getEpochSec
 
-  def isBefore(that: RemoteInstantSyntax): Remote[Boolean] = self.getEpochSec < that.getEpochSec
+  def isAfter(that: Remote[Instant]): Remote[Boolean]  = self.getEpochSecond > that.getEpochSecond
+  def isBefore(that: Remote[Instant]): Remote[Boolean] = self.getEpochSecond < that.getEpochSecond
 
-  def getEpochSec: Remote[Long] =
-    Remote.InstantToLong(self)
+  def getEpochSecond: Remote[Long] = Remote.InstantToTuple(self.widen[Instant])._1
+  def getNano: Remote[Int]         = Remote.InstantToTuple(self.widen[Instant])._2
 
-  def toEpochSecsNanos: Remote[(Long, Int)] =
-    Remote.InstantToTuple(self)
+  def truncatedTo(unit: Remote[TemporalUnit]): Remote[Instant] = Remote.InstantTruncate(self, unit)
 
-  def plusDuration(duration: Remote[Duration]): Remote[Instant] = {
-    val durationSecsNanos     = duration.toSecsNanos
-    val instantEpochSecsNanos = toEpochSecsNanos
-
-    Remote.ToInstantPlusDuration(instantEpochSecsNanos, durationSecsNanos)
-  }
-
-  def minusDuration(duration: Remote[Duration]): Remote[Instant] = {
-    val durationSecsNanos     = duration.toSecsNanos
-    val instantEpochSecsNanos = toEpochSecsNanos
-
-    Remote.ToInstantMinusDuration(instantEpochSecsNanos, durationSecsNanos)
-  }
-
-  def get(field: Remote[TemporalField]): Remote[Int] = Remote.TemporalFieldOfInstant(self, field)
+  def plusDuration(duration: Remote[Duration]): Remote[Instant] =
+    Remote.InstantPlusDuration(self, duration)
 
   def plus(amountToAdd: Remote[TemporalAmount]): Remote[Instant] =
     self.plusDuration(Remote.DurationFromTemporalAmount(amountToAdd))
 
   def plus(amountToAdd: Remote[Long], unit: Remote[TemporalUnit]): Remote[Instant] =
-    self.plusDuration(Remote.AmountToDuration(amountToAdd, unit))
+    self.plusDuration(Remote.DurationFromAmount(amountToAdd, unit))
 
   def plusSeconds(secondsToAdd: Remote[Long]): Remote[Instant] =
-    self.plusDuration(Remote.AmountToDuration(secondsToAdd, Remote(ChronoUnit.SECONDS)))
+    self.plus(secondsToAdd, Remote(ChronoUnit.SECONDS))
 
   def plusMillis(milliSecondsToAdd: Remote[Long]): Remote[Instant] =
-    self.plusDuration(Remote.AmountToDuration(milliSecondsToAdd, Remote(ChronoUnit.MILLIS)))
+    self.plus(milliSecondsToAdd, Remote(ChronoUnit.MILLIS))
 
   def plusNanos(nanoSecondsToAdd: Remote[Long]): Remote[Instant] =
-    self.plusDuration(Remote.AmountToDuration(nanoSecondsToAdd, Remote(ChronoUnit.NANOS)))
+    self.plus(nanoSecondsToAdd, Remote(ChronoUnit.NANOS))
+
+  def minusDuration(duration: Remote[Duration]): Remote[Instant] =
+    Remote.InstantMinusDuration(self, duration)
 
   def minus(amountToSubtract: Remote[TemporalAmount]): Remote[Instant] =
     self.minusDuration(Remote.DurationFromTemporalAmount(amountToSubtract))
 
   def minus(amountToSubtract: Remote[Long], unit: Remote[TemporalUnit]): Remote[Instant] =
-    self.minusDuration(Remote.AmountToDuration(amountToSubtract, unit))
+    self.minusDuration(Remote.DurationFromAmount(amountToSubtract, unit))
 
   def minusSeconds(secondsToSubtract: Remote[Long]): Remote[Instant] =
-    self.minusDuration(Remote.AmountToDuration(secondsToSubtract, Remote(ChronoUnit.SECONDS)))
+    self.minus(secondsToSubtract, Remote(ChronoUnit.SECONDS))
 
   def minusNanos(nanosecondsToSubtract: Remote[Long]): Remote[Instant] =
-    self.minusDuration(Remote.AmountToDuration(nanosecondsToSubtract, Remote(ChronoUnit.NANOS)))
+    self.minus(nanosecondsToSubtract, Remote(ChronoUnit.NANOS))
 
   def minusMillis(milliSecondsToSubtract: Remote[Long]): Remote[Instant] =
-    self.minusDuration(Remote.AmountToDuration(milliSecondsToSubtract, Remote(ChronoUnit.MILLIS)))
+    self.minus(milliSecondsToSubtract, Remote(ChronoUnit.MILLIS))
 }
 
-object RemoteInstantSyntax {
-  def now(): Remote[Instant] = Remote(Instant.now())
-
-  def now(clock: Remote[Clock]): Remote[Instant] = ???
-
-  def ofEpochSecond(second: Remote[Long]): Remote[Instant] = ???
-
-  def ofEpochMilli(milliSecond: Remote[Long]): Remote[Instant] = ???
-
-  def parse(charSeq: Remote[String]): Remote[Instant] = ???
+object RemoteInstant {
+  def now: Remote[Instant]                            = Remote(Instant.now())
+  def now(clock: Remote[Clock]): Remote[Instant]      = Remote.InstantFromClock(clock)
+  def parse(charSeq: Remote[String]): Remote[Instant] = Remote.InstantFromString(charSeq)
 }

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteDurationSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteDurationSpec.scala
@@ -1,7 +1,7 @@
 package zio.flow
 
 import zio.flow.utils.RemoteAssertionSyntax.RemoteAssertionOps
-import zio.random.Random
+import zio.flow.utils.TestGen
 import zio.test._
 
 object RemoteDurationSpec extends ZIOSpecDefault {
@@ -37,37 +37,34 @@ object RemoteDurationSpec extends ZIOSpecDefault {
       }
     },
     test("plusNanos") {
-      check(Gen.finiteDuration, Gen.long) { (d, l) =>
+      check(Gen.finiteDuration, TestGen.long) { (d, l) =>
         Remote(d).plusNanos(l) <-> d.plusNanos(l)
       }
     },
     test("plusSeconds") {
-      check(Gen.finiteDuration, Gen.long) { (d, l) =>
+      check(Gen.finiteDuration, TestGen.long) { (d, l) =>
         Remote(d).plusSeconds(l) <-> d.plusSeconds(l)
       }
     },
     test("plusMinutes") {
-      check(Gen.finiteDuration, Gen.long) { (d, l) =>
+      check(Gen.finiteDuration, TestGen.long) { (d, l) =>
         Remote(d).plusMinutes(l) <-> d.plusMinutes(l)
       }
     },
     test("plusHours") {
-      check(Gen.finiteDuration, Gen.long) { (d, l) =>
+      check(Gen.finiteDuration, TestGen.long) { (d, l) =>
         Remote(d).plusHours(l) <-> d.plusHours(l)
       }
     },
     test("plusDays") {
-      check(Gen.finiteDuration, Gen.long) { (d, l) =>
+      check(Gen.finiteDuration, TestGen.long) { (d, l) =>
         Remote(d).plusDays(l) <-> d.plusDays(l)
       }
     },
-    test("toSeconds") {
-      check(Gen.finiteDuration) { d =>
+    testM("toSeconds") {
+      check(Gen.anyFiniteDuration) { d =>
         Remote(d).toSeconds <-> d.getSeconds
       }
     }
   )
-
-  private def genLong: Gen[Random, Long] =
-    Gen.long(Int.MinValue.toLong, Int.MaxValue.toLong)
 }

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteDurationSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteDurationSpec.scala
@@ -1,6 +1,7 @@
 package zio.flow
 
 import zio.flow.utils.RemoteAssertionSyntax.RemoteAssertionOps
+import zio.random.Random
 import zio.test._
 
 object RemoteDurationSpec extends ZIOSpecDefault {
@@ -65,6 +66,8 @@ object RemoteDurationSpec extends ZIOSpecDefault {
         Remote(d).toSeconds <-> d.getSeconds
       }
     }
-  ) @@ TestAspect.ignore
+  )
 
+  private def genLong: Gen[Random, Long] =
+    Gen.long(Int.MinValue.toLong, Int.MaxValue.toLong)
 }

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteDurationSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteDurationSpec.scala
@@ -8,7 +8,7 @@ object RemoteDurationSpec extends ZIOSpecDefault {
   override def spec = suite("RemoteDurationSpec")(
     test("plusDuration2") {
       check(Gen.finiteDuration, Gen.finiteDuration) { case (d1, d2) =>
-        (Remote(d1) plusDuration2 Remote(d2)) <-> (d1 plus d2)
+        (Remote(d1) plusDuration Remote(d2)) <-> (d1 plus d2)
       }
     },
     test("minusDuration") {

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteDurationSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteDurationSpec.scala
@@ -4,36 +4,13 @@ import zio.flow.utils.RemoteAssertionSyntax.RemoteAssertionOps
 import zio.flow.utils.TestGen
 import zio.test._
 
+import java.time.temporal.ChronoUnit
+
 object RemoteDurationSpec extends ZIOSpecDefault {
   override def spec = suite("RemoteDurationSpec")(
-    test("plusDuration2") {
+    test("plus") {
       check(Gen.finiteDuration, Gen.finiteDuration) { case (d1, d2) =>
-        (Remote(d1) plusDuration Remote(d2)) <-> (d1 plus d2)
-      }
-    },
-    test("minusDuration") {
-      check(Gen.finiteDuration, Gen.finiteDuration) { case (d1, d2) =>
-        (Remote(d1) minusDuration Remote(d2)) <-> (d1 minus d2)
-      }
-    },
-    test("getSeconds") {
-      check(Gen.finiteDuration) { d =>
-        Remote(d).getSeconds <-> d.getSeconds
-      }
-    },
-    test("getNano") {
-      check(Gen.finiteDuration) { d =>
-        Remote(d).getNano <-> d.getNano.toLong
-      }
-    },
-    test("isZero") {
-      check(Gen.finiteDuration) { d =>
-        Remote(d).isZero <-> d.isZero
-      }
-    },
-    test("isNegative") {
-      check(Gen.finiteDuration) { d =>
-        Remote(d).isNegative <-> d.isNegative
+        (Remote(d1) plus Remote(d2)) <-> (d1 plus d2)
       }
     },
     test("plusNanos") {
@@ -61,9 +38,74 @@ object RemoteDurationSpec extends ZIOSpecDefault {
         Remote(d).plusDays(l) <-> d.plusDays(l)
       }
     },
-    testM("toSeconds") {
-      check(Gen.anyFiniteDuration) { d =>
-        Remote(d).toSeconds <-> d.getSeconds
+    test("plus amount of temporal units") {
+      check(Gen.finiteDuration, TestGen.long) { (d, l) =>
+        (Remote(d).plus(l, ChronoUnit.DAYS) <-> d.plus(l, ChronoUnit.DAYS)) &&
+        (Remote(d).plus(l, ChronoUnit.HOURS) <-> d.plus(l, ChronoUnit.HOURS)) &&
+        (Remote(d).plus(l, ChronoUnit.MINUTES) <-> d.plus(l, ChronoUnit.MINUTES)) &&
+        (Remote(d).plus(l, ChronoUnit.SECONDS) <-> d.plus(l, ChronoUnit.SECONDS)) &&
+        (Remote(d).plus(l, ChronoUnit.MILLIS) <-> d.plus(l, ChronoUnit.MILLIS)) &&
+        (Remote(d).plus(l, ChronoUnit.NANOS) <-> d.plus(l, ChronoUnit.NANOS))
+      }
+    },
+    test("minus") {
+      check(Gen.finiteDuration, Gen.anyFiniteDuration) { case (d1, d2) =>
+        (Remote(d1) minus Remote(d2)) <-> (d1 minus d2)
+      }
+    },
+    test("minusDays") {
+      check(Gen.finiteDuration, TestGen.long) { case (d, l) =>
+        (Remote(d) minusDays Remote(l)) <-> (d minusDays l)
+      }
+    },
+    test("minusHours") {
+      check(Gen.finiteDuration, TestGen.long) { case (d, l) =>
+        (Remote(d) minusHours Remote(l)) <-> (d minusHours l)
+      }
+    },
+    test("minusMinutes") {
+      check(Gen.finiteDuration, TestGen.long) { case (d, l) =>
+        (Remote(d) minusMinutes Remote(l)) <-> (d minusMinutes l)
+      }
+    },
+    test("minusSeconds") {
+      check(Gen.finiteDuration, TestGen.long) { case (d, l) =>
+        (Remote(d) minusSeconds Remote(l)) <-> (d minusSeconds l)
+      }
+    },
+    test("minusNanos") {
+      check(Gen.finiteDuration, TestGen.long) { case (d, l) =>
+        (Remote(d) minusNanos Remote(l)) <-> (d minusNanos l)
+      }
+    },
+    test("minus amount of temporal units") {
+      check(Gen.finiteDuration, TestGen.long) { (d, l) =>
+        (Remote(d).minus(l, ChronoUnit.DAYS) <-> d.minus(l, ChronoUnit.DAYS)) &&
+        (Remote(d).minus(l, ChronoUnit.HOURS) <-> d.minus(l, ChronoUnit.HOURS)) &&
+        (Remote(d).minus(l, ChronoUnit.MINUTES) <-> d.minus(l, ChronoUnit.MINUTES)) &&
+        (Remote(d).minus(l, ChronoUnit.SECONDS) <-> d.minus(l, ChronoUnit.SECONDS)) &&
+        (Remote(d).minus(l, ChronoUnit.MILLIS) <-> d.minus(l, ChronoUnit.MILLIS)) &&
+        (Remote(d).minus(l, ChronoUnit.NANOS) <-> d.minus(l, ChronoUnit.NANOS))
+      }
+    },
+    test("getSeconds") {
+      check(Gen.finiteDuration) { d =>
+        Remote(d).getSeconds <-> d.getSeconds
+      }
+    },
+    test("getNano") {
+      check(Gen.finiteDuration) { d =>
+        Remote(d).getNano <-> d.getNano.toLong
+      }
+    },
+    test("isZero") {
+      check(Gen.finiteDuration) { d =>
+        Remote(d).isZero <-> d.isZero
+      }
+    },
+    test("isNegative") {
+      check(Gen.finiteDuration) { d =>
+        Remote(d).isNegative <-> d.isNegative
       }
     }
   )

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteDurationSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteDurationSpec.scala
@@ -49,7 +49,7 @@ object RemoteDurationSpec extends ZIOSpecDefault {
       }
     },
     test("minus") {
-      check(Gen.finiteDuration, Gen.anyFiniteDuration) { case (d1, d2) =>
+      check(Gen.finiteDuration, Gen.finiteDuration) { case (d1, d2) =>
         (Remote(d1) minus Remote(d2)) <-> (d1 minus d2)
       }
     },

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteInstantSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteInstantSpec.scala
@@ -1,10 +1,8 @@
 package zio.flow
 
 import zio.flow.utils.RemoteAssertionSyntax.RemoteAssertionOps
-import zio.random.Random
+import zio.flow.utils.TestGen
 import zio.test._
-
-import java.time.Instant
 
 object RemoteInstantSpec extends ZIOSpecDefault {
   override def spec = suite("RemoteInstantSpec")(
@@ -29,40 +27,34 @@ object RemoteInstantSpec extends ZIOSpecDefault {
       }
     },
     test("plusSeconds") {
-      check(genInstant, genLong) { case (i, s) =>
+      check(TestGen.instant, TestGen.long) { case (i, s) =>
         Remote(i).plusSeconds(Remote(s)) <-> i.plusSeconds(s)
       }
     },
     test("plusMills") {
-      check(genInstant, genLong) { case (i, ms) =>
+      check(TestGen.instant, TestGen.long) { case (i, ms) =>
         Remote(i).plusMillis(Remote(ms)) <-> i.plusMillis(ms)
       }
     },
     test("plusNanos") {
-      check(genInstantt, Gen.long) { case (i, ns) =>
-        Remote(i).plusMillis(Remote(ns)) <-> i.plusNanos(ns)
+      check(TestGen.instant, TestGen.long) { case (i, ns) =>
+        Remote(i).plusNanos(Remote(ns)) <-> i.plusNanos(ns)
       }
     },
     test("minusSeconds") {
-      check(genInstant, genLong) { case (i, s) =>
+      check(TestGen.instant, TestGen.long) { case (i, s) =>
         Remote(i).minusSeconds(Remote(s)) <-> i.minusSeconds(s)
       }
     },
     test("minusMills") {
-      check(genInstant, genLong) { case (i, ms) =>
+      check(TestGen.instant, TestGen.long) { case (i, ms) =>
         Remote(i).minusMillis(Remote(ms)) <-> i.minusMillis(ms)
       }
     },
     test("minusNanos") {
-      check(genInstant, genLong) { case (i, ns) =>
+      check(TestGen.instant, TestGen.long) { case (i, ns) =>
         Remote(i).minusNanos(Remote(ns)) <-> i.minusNanos(ns)
       }
     }
   )
-
-  private def genLong: Gen[Random, Long] =
-    Gen.long(Int.MinValue.toLong, Int.MaxValue.toLong)
-
-  private def genInstant: Gen[Random, Instant] =
-    Gen.instant(Instant.EPOCH, Instant.MAX)
 }

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteInstantSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteInstantSpec.scala
@@ -2,7 +2,10 @@ package zio.flow
 
 import zio.flow.utils.RemoteAssertionSyntax.RemoteAssertionOps
 import zio.flow.utils.TestGen
+import zio.schema.Schema
 import zio.test._
+
+import java.time.temporal.{ChronoField, ChronoUnit}
 
 object RemoteInstantSpec extends ZIOSpecDefault {
   override def spec = suite("RemoteInstantSpec")(
@@ -16,14 +19,24 @@ object RemoteInstantSpec extends ZIOSpecDefault {
         (Remote(i1) isBefore Remote(i2)) <-> (i1 isBefore i2)
       }
     },
-    test("plusDuration") {
-      check(Gen.instant, Gen.finiteDuration) { case (i, d2) =>
-        (Remote(i) plusDuration Remote(d2)) <-> (i plus d2)
+    test("getEpochSecond") {
+      check(Gen.instant) { d =>
+        Remote(d).getEpochSecond <-> d.getEpochSecond
       }
     },
-    test("getEpochSec") {
-      check(Gen.instant) { d =>
-        Remote(d).getEpochSec <-> d.getEpochSecond
+    test("getNano") {
+      check(Gen.instant) { i =>
+        Remote(i).getNano <-> i.getNano
+      }
+    },
+    test("truncatedTo") {
+      check(Gen.instant, TestGen.chronoUnit) { case (i, u) =>
+        Remote(i).truncatedTo(Remote(u)) <-> i.truncatedTo(u)
+      }
+    },
+    test("plusDuration") {
+      check(Gen.anyInstant, Gen.finiteDuration) { case (i, d2) =>
+        (Remote(i) plusDuration Remote(d2)) <-> (i plus d2)
       }
     },
     test("plusSeconds") {
@@ -39,6 +52,11 @@ object RemoteInstantSpec extends ZIOSpecDefault {
     test("plusNanos") {
       check(TestGen.instant, TestGen.long) { case (i, ns) =>
         Remote(i).plusNanos(Remote(ns)) <-> i.plusNanos(ns)
+      }
+    },
+    test("minusDuration") {
+      check(Gen.instant, Gen.finiteDuration) { case (i, d2) =>
+        (Remote(i) minusDuration Remote(d2)) <-> (i minus d2)
       }
     },
     test("minusSeconds") {
@@ -57,4 +75,10 @@ object RemoteInstantSpec extends ZIOSpecDefault {
       }
     }
   )
+
+  implicit val chronoFieldSchema: Schema[ChronoField] =
+    Schema[String].transform(ChronoField.valueOf, _.name())
+
+  implicit val chronoUnitSchema: Schema[ChronoUnit] =
+    Schema[String].transform(ChronoUnit.valueOf, _.name())
 }

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteInstantSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteInstantSpec.scala
@@ -1,7 +1,10 @@
 package zio.flow
 
 import zio.flow.utils.RemoteAssertionSyntax.RemoteAssertionOps
+import zio.random.Random
 import zio.test._
+
+import java.time.Instant
 
 object RemoteInstantSpec extends ZIOSpecDefault {
   override def spec = suite("RemoteInstantSpec")(
@@ -26,34 +29,40 @@ object RemoteInstantSpec extends ZIOSpecDefault {
       }
     },
     test("plusSeconds") {
-      check(Gen.instant, Gen.long) { case (i, s) =>
+      check(genInstant, genLong) { case (i, s) =>
         Remote(i).plusSeconds(Remote(s)) <-> i.plusSeconds(s)
       }
     },
     test("plusMills") {
-      check(Gen.instant, Gen.long) { case (i, ms) =>
+      check(genInstant, genLong) { case (i, ms) =>
         Remote(i).plusMillis(Remote(ms)) <-> i.plusMillis(ms)
       }
     },
     test("plusNanos") {
-      check(Gen.instant, Gen.long) { case (i, ns) =>
+      check(genInstantt, Gen.long) { case (i, ns) =>
         Remote(i).plusMillis(Remote(ns)) <-> i.plusNanos(ns)
       }
     },
     test("minusSeconds") {
-      check(Gen.instant, Gen.long) { case (i, s) =>
+      check(genInstant, genLong) { case (i, s) =>
         Remote(i).minusSeconds(Remote(s)) <-> i.minusSeconds(s)
       }
     },
     test("minusMills") {
-      check(Gen.instant, Gen.long) { case (i, ms) =>
+      check(genInstant, genLong) { case (i, ms) =>
         Remote(i).minusMillis(Remote(ms)) <-> i.minusMillis(ms)
       }
     },
     test("minusNanos") {
-      check(Gen.instant, Gen.long) { case (i, ns) =>
+      check(genInstant, genLong) { case (i, ns) =>
         Remote(i).minusNanos(Remote(ns)) <-> i.minusNanos(ns)
       }
     }
-  ) @@ TestAspect.ignore
+  )
+
+  private def genLong: Gen[Random, Long] =
+    Gen.long(Int.MinValue.toLong, Int.MaxValue.toLong)
+
+  private def genInstant: Gen[Random, Instant] =
+    Gen.instant(Instant.EPOCH, Instant.MAX)
 }

--- a/zio-flow/shared/src/test/scala/zio/flow/RemoteInstantSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/RemoteInstantSpec.scala
@@ -35,7 +35,7 @@ object RemoteInstantSpec extends ZIOSpecDefault {
       }
     },
     test("plusDuration") {
-      check(Gen.anyInstant, Gen.finiteDuration) { case (i, d2) =>
+      check(Gen.instant, Gen.finiteDuration) { case (i, d2) =>
         (Remote(i) plusDuration Remote(d2)) <-> (i plus d2)
       }
     },

--- a/zio-flow/shared/src/test/scala/zio/flow/utils/TestGen.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/utils/TestGen.scala
@@ -1,6 +1,6 @@
 package zio.flow.utils
 
-import zio.random.Random
+import zio.Random
 import zio.test.Gen
 
 import java.time.Instant

--- a/zio-flow/shared/src/test/scala/zio/flow/utils/TestGen.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/utils/TestGen.scala
@@ -1,0 +1,15 @@
+package zio.flow.utils
+
+import zio.random.Random
+import zio.test.Gen
+
+import java.time.Instant
+
+object TestGen {
+
+  def long: Gen[Random, Long] =
+    Gen.long(Int.MinValue.toLong, Int.MaxValue.toLong)
+
+  def instant: Gen[Random, Instant] =
+    Gen.instant(Instant.EPOCH, Instant.MAX)
+}

--- a/zio-flow/shared/src/test/scala/zio/flow/utils/TestGen.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/utils/TestGen.scala
@@ -4,6 +4,7 @@ import zio.random.Random
 import zio.test.Gen
 
 import java.time.Instant
+import java.time.temporal.{ChronoField, ChronoUnit}
 
 object TestGen {
 
@@ -12,4 +13,19 @@ object TestGen {
 
   def instant: Gen[Random, Instant] =
     Gen.instant(Instant.EPOCH, Instant.MAX)
+
+  def chronoField: Gen[Random, ChronoField] =
+    Gen.elements(
+      ChronoField.SECOND_OF_DAY,
+      ChronoField.MINUTE_OF_HOUR,
+      ChronoField.HOUR_OF_DAY
+    )
+
+  def chronoUnit: Gen[Random, ChronoUnit] =
+    Gen.elements(
+      ChronoUnit.SECONDS,
+      ChronoUnit.MILLIS,
+      ChronoUnit.NANOS
+    )
+
 }


### PR DESCRIPTION
Hey guys!
This is an attempt to close #51 
There were few minor problems that fail mentioned specs:
 -  each time you get a new instance of `Remote[Duration]` (or `Remote[Instant]`) by adding/subtracting time units, the nano-adjustment has not been taken into account;
 - The tests also fail wherever the value of `Gen.anyLong` is added to/subtracted from an instance of Duration (or Instant) and the resulting value falls outside the boundaries of [Duration.Min...Duration.Max] (same for Instant)