### PR TITLE
ZFlow and Remote related cleanups

### DIFF
--- a/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
@@ -188,7 +188,7 @@ object Remote {
   }
 
   object Variable {
-    implicit def schema[A]: Schema[Variable[A]] =
+    def schema[A]: Schema[Variable[A]] =
       Schema.CaseClass2[String, FlowSchemaAst, Variable[A]](
         Schema.Field("identifier", Schema.primitive[String]),
         Schema.Field("schema", FlowSchemaAst.schema),

--- a/zio-flow/shared/src/main/scala/zio/flow/RemoteVariableReference.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/RemoteVariableReference.scala
@@ -1,0 +1,10 @@
+package zio.flow
+
+import zio.schema.{DeriveSchema, Schema}
+
+case class RemoteVariableReference[A](name: RemoteVariableName) {
+  def toRemote(implicit schema: Schema[A]): Remote.Variable[A] = Remote.Variable(name, schema)
+}
+object RemoteVariableReference {
+  implicit def schema[A]: Schema[RemoteVariableReference[A]] = DeriveSchema.gen
+}

--- a/zio-flow/shared/src/main/scala/zio/flow/Syntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/Syntax.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021-2022 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.flow
+
+import zio.Duration
+import zio.flow.remote.{
+  RemoteBooleanSyntax,
+  RemoteDurationSyntax,
+  RemoteEitherSyntax,
+  RemoteExecutingFlowSyntax,
+  RemoteFractionalSyntax,
+  RemoteInstantSyntax,
+  RemoteListSyntax,
+  RemoteNumericSyntax,
+  RemoteOptionSyntax,
+  RemoteRelationalSyntax,
+  RemoteStringSyntax,
+  RemoteTuple2Syntax,
+  RemoteTuple3Syntax,
+  RemoteTuple4Syntax,
+  RemoteVariableSyntax
+}
+import java.time.Instant
+import scala.language.implicitConversions
+
+trait Syntax {
+
+  implicit def RemoteVariable[A](remote: Remote[RemoteVariableReference[A]]): RemoteVariableSyntax[A] =
+    new RemoteVariableSyntax(
+      remote
+    )
+
+  implicit def RemoteInstant(remote: Remote[Instant]): RemoteInstantSyntax = new RemoteInstantSyntax(
+    remote
+  )
+  implicit def RemoteDuration(remote: Remote[Duration]): RemoteDurationSyntax = new RemoteDurationSyntax(
+    remote
+  )
+  implicit def RemoteBoolean(remote: Remote[Boolean]): RemoteBooleanSyntax = new RemoteBooleanSyntax(remote)
+
+  implicit def RemoteEither[A, B](remote: Remote[Either[A, B]]): RemoteEitherSyntax[A, B] = new RemoteEitherSyntax(
+    remote
+  )
+  implicit def RemoteTuple2[A, B](remote: Remote[(A, B)]): RemoteTuple2Syntax[A, B] = new RemoteTuple2Syntax(remote)
+
+  implicit def RemoteTuple3[A, B, C](remote: Remote[(A, B, C)]): RemoteTuple3Syntax[A, B, C] = new RemoteTuple3Syntax(
+    remote
+  )
+  implicit def RemoteTuple4[A, B, C, D](remote: Remote[(A, B, C, D)]): RemoteTuple4Syntax[A, B, C, D] =
+    new RemoteTuple4Syntax(remote)
+
+  implicit def RemoteList[A](remote: Remote[List[A]]): RemoteListSyntax[A] = new RemoteListSyntax[A](remote)
+
+  implicit def RemoteOption[A](remote: Remote[Option[A]]): RemoteOptionSyntax[A] = new RemoteOptionSyntax[A](remote)
+
+  implicit def RemoteString(remote: Remote[String]): RemoteStringSyntax = new RemoteStringSyntax(remote)
+
+  implicit def RemoteExecutingFlow[A](remote: Remote[A]): RemoteExecutingFlowSyntax[A] =
+    new RemoteExecutingFlowSyntax[A](remote)
+
+  implicit def RemoteNumeric[A](remote: Remote[A]): RemoteNumericSyntax[A] = new RemoteNumericSyntax[A](remote)
+
+  implicit def RemoteRelational[A](remote: Remote[A]): RemoteRelationalSyntax[A] = new RemoteRelationalSyntax[A](remote)
+
+  implicit def RemoteFractional[A](remote: Remote[A]): RemoteFractionalSyntax[A] = new RemoteFractionalSyntax[A](remote)
+
+  implicit class ZFlowSyntax[R, E, A](flow: ZFlow[R, E, A]) {
+    def toRemote: Remote.Flow[R, E, A] = Remote.Flow(flow)
+  }
+}

--- a/zio-flow/shared/src/main/scala/zio/flow/ZFlow.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/ZFlow.scala
@@ -217,16 +217,19 @@ object ZFlow {
       Schema.Case("WaitTill", schema[A], _.asInstanceOf[WaitTill])
   }
 
-  final case class Modify[A, B](svar: Remote[Remote.Variable[A]], f: EvaluatedRemoteFunction[A, (B, A)])(implicit
-    val resultSchema: Schema[B]
+  final case class Modify[A, B](svar: Remote[RemoteVariableReference[A]], f: EvaluatedRemoteFunction[A, (B, A)])(
+    implicit val resultSchema: Schema[B]
   ) extends ZFlow[Any, Nothing, B] {
     val errorSchema = Schema[ZNothing]
   }
 
   object Modify {
     def schema[A, B]: Schema[Modify[A, B]] =
-      Schema.CaseClass3[Remote[Remote.Variable[A]], EvaluatedRemoteFunction[A, (B, A)], FlowSchemaAst, Modify[A, B]](
-        Schema.Field("svar", Remote.schema[Remote.Variable[A]]), // TODO: eliminate the need of recursive remote
+      Schema.CaseClass3[Remote[RemoteVariableReference[A]], EvaluatedRemoteFunction[A, (B, A)], FlowSchemaAst, Modify[
+        A,
+        B
+      ]](
+        Schema.Field("svar", Remote.schema[RemoteVariableReference[A]]),
         Schema.Field("f", EvaluatedRemoteFunction.schema[A, (B, A)]),
         Schema.Field("resultSchema", FlowSchemaAst.schema),
         { case (svar, f, schemaAst) =>
@@ -667,9 +670,9 @@ object ZFlow {
       Schema.Case("Fail", schema[E], _.asInstanceOf[Fail[E]])
   }
 
-  final case class NewVar[A](name: String, initial: Remote[A]) extends ZFlow[Any, Nothing, Remote.Variable[A]] {
+  final case class NewVar[A](name: String, initial: Remote[A]) extends ZFlow[Any, Nothing, RemoteVariableReference[A]] {
     val errorSchema  = Schema[ZNothing]
-    val resultSchema = Remote.Variable.schema[A]
+    val resultSchema = RemoteVariableReference.schema[A]
   }
 
   object NewVar {
@@ -777,7 +780,7 @@ object ZFlow {
 
   def input[R: Schema]: ZFlow[R, ZNothing, R] = Input[R]()
 
-  def newVar[A](name: String, initial: Remote[A]): ZFlow[Any, ZNothing, Remote.Variable[A]] =
+  def newVar[A](name: String, initial: Remote[A]): ZFlow[Any, ZNothing, RemoteVariableReference[A]] =
     NewVar(name, initial)
 
   def now: ZFlow[Any, ZNothing, Instant] = Now

--- a/zio-flow/shared/src/main/scala/zio/flow/ZFlow.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/ZFlow.scala
@@ -302,6 +302,7 @@ object ZFlow {
       Schema.Case("Log", schema, _.asInstanceOf[Log])
   }
 
+  // TODO: why not get the input from the flow environment?
   final case class RunActivity[R, A](input: Remote[R], activity: Activity[R, A]) extends ZFlow[Any, ActivityError, A] {
     val errorSchema  = Schema[ActivityError]
     val resultSchema = activity.resultSchema
@@ -361,7 +362,6 @@ object ZFlow {
 
   final case class Ensuring[R, E, A](flow: ZFlow[R, E, A], finalizer: ZFlow[Any, ZNothing, Unit])
       extends ZFlow[R, E, A] {
-    type ValueR = R
     type ValueE = E
     type ValueA = A
 

--- a/zio-flow/shared/src/main/scala/zio/flow/internal/PersistentExecutor.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/internal/PersistentExecutor.scala
@@ -187,14 +187,11 @@ final case class PersistentExecutor(
 
             val f = f0.asInstanceOf[EvaluatedRemoteFunction[Any, (A, Any)]]
             for {
-              _        <- ZIO.logDebug(s"Modify $svar")
-              variable <- eval(svar)
-              optValue <- RemoteContext.getVariable(variable.identifier)
-              value <- ZIO
-                         .fromOption(optValue)
-                         .orElseFail(new IOException(s"Undefined variable ${variable.identifier} in Modify"))
+              _                 <- ZIO.logDebug(s"Modify $svar")
+              variableReference <- eval(svar)
+              variable           = Remote.Variable(variableReference.name, f.input.schema)
               //            _                                      <- ZIO.debug(s"Modify: ${variable.identifier}'s previous value was $value")
-              dynTuple <- evalDynamic(f(Remote.Literal(value, variable.schemaA)))
+              dynTuple <- evalDynamic(f(variable))
               tuple <- dynTuple.value match {
                          case DynamicValue.Tuple(dynResult, newValue) => ZIO.succeed((dynResult, newValue))
                          case _                                       => ZIO.fail(new IOException(s"Modify's result was not a tuple"))
@@ -462,21 +459,12 @@ final case class PersistentExecutor(
           case NewVar(name, initial) =>
             for {
               schemaAndValue <- evalDynamic(initial)
-              vref            = Remote.Variable(RemoteVariableName(name), schemaAndValue.schema)
+              vref            = RemoteVariableReference[Any](RemoteVariableName(name))
               _              <- RemoteContext.setVariable(RemoteVariableName(name), schemaAndValue.value)
               _              <- ZIO.logDebug(s"Created new variable $name")
             } yield StepResult(
               StateChange.addVariable(name, schemaAndValue),
-              Some(
-                Right(
-                  Remote.Literal(
-                    SchemaAndValue.fromSchemaAndValue(
-                      Remote.Variable.schema[Any],
-                      vref.asInstanceOf[Remote.Variable[Any]]
-                    )
-                  )
-                )
-              )
+              Some(Right(Remote(vref)))
             )
 
           case i @ Iterate(initial, step0, predicate) =>
@@ -489,7 +477,7 @@ final case class PersistentExecutor(
             def iterate(
               step: Remote.EvaluatedRemoteFunction[i.ValueA, ZFlow[Any, i.ValueE, i.ValueA]],
               predicate: EvaluatedRemoteFunction[i.ValueA, Boolean],
-              stateVar: Remote[Remote.Variable[i.ValueA]],
+              stateVar: Remote[RemoteVariableReference[i.ValueA]],
               boolRemote: Remote[Boolean]
             ): ZFlow[Any, i.ValueE, i.ValueA] =
               ZFlow.ifThenElse(boolRemote)(

--- a/zio-flow/shared/src/main/scala/zio/flow/internal/PersistentExecutor.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/internal/PersistentExecutor.scala
@@ -349,21 +349,19 @@ final case class PersistentExecutor(
                               case Some(Right(dynamicSuccess)) =>
                                 // succeeded
                                 ZIO.right(
-                                  Remote.Literal(DynamicValue.SomeValue(dynamicSuccess), Schema.option(timeout.schemaA))
+                                  Remote.Literal(DynamicValue.SomeValue(dynamicSuccess), timeout.resultSchema)
                                 )
                               case Some(Left(Left(fatal))) =>
                                 // failed with fatal error
                                 ZIO.die(new IOException("Awaited flow died", fatal))
                               case Some(Left(Right(dynamicError))) =>
                                 // failed with typed error
-                                ZIO.left(Remote[timeout.ValueE](dynamicError)(timeout.schemaE))
+                                ZIO.left(Remote.Literal(dynamicError, timeout.errorSchema))
                               case None =>
                                 // timed out
                                 interruptFlow(forkId).as(
                                   Right(
-                                    Remote[Option[timeout.ValueA]](None)(
-                                      Schema.option(timeout.schemaA)
-                                    )
+                                    Remote.Literal(DynamicValue.NoneValue, timeout.resultSchema)
                                   )
                                 )
                             }

--- a/zio-flow/shared/src/main/scala/zio/flow/internal/PersistentExecutor.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/internal/PersistentExecutor.scala
@@ -208,13 +208,6 @@ final case class PersistentExecutor(
                             ) // TODO: is it ok to add it only _after_ resume?
             } yield stepResult
 
-          case apply @ Apply(_) =>
-            val env         = state.currentEnvironment
-            val appliedFlow = apply.lambda(env)
-            for {
-              nextFlow <- eval(appliedFlow)
-            } yield StepResult(StateChange.setCurrent(nextFlow), None)
-
           case fold @ Fold(_, _, _) =>
             val cont =
               Instruction.Continuation[fold.ValueR, fold.ValueA, fold.ValueE, fold.ValueE2, fold.ValueB](

--- a/zio-flow/shared/src/main/scala/zio/flow/package.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/package.scala
@@ -17,69 +17,16 @@
 package zio
 
 import zio.flow.FlowId.unwrap
-import zio.flow.remote._
 import zio.prelude.Newtype
 import zio.schema.Schema
 
 import java.nio.charset.StandardCharsets
-import java.time.Instant
-import scala.language.implicitConversions
 
-package object flow extends Schemas {
-  type RemoteDuration    = Remote[Duration]
-  type RemoteInstant     = Remote[Instant]
-  type RemoteVariable[A] = Remote.Variable[A]
-  type SchemaOption[A]   = Schema.Optional[A]
-  type SchemaList[A]     = Schema[List[A]]
-
-  implicit def RemoteVariable[A](remote: Remote[Remote.Variable[A]]): RemoteVariableSyntax[A] =
-    new RemoteVariableSyntax(
-      remote
-    )
-
-  implicit def RemoteInstant(remote: Remote[Instant]): RemoteInstantSyntax = new RemoteInstantSyntax(
-    remote
-  )
-  implicit def RemoteDuration(remote: Remote[Duration]): RemoteDurationSyntax = new RemoteDurationSyntax(
-    remote
-  )
-  implicit def RemoteBoolean(remote: Remote[Boolean]): RemoteBooleanSyntax = new RemoteBooleanSyntax(remote)
-
-  implicit def RemoteEither[A, B](remote: Remote[Either[A, B]]): RemoteEitherSyntax[A, B] = new RemoteEitherSyntax(
-    remote
-  )
-  implicit def RemoteTuple2[A, B](remote: Remote[(A, B)]): RemoteTuple2Syntax[A, B] = new RemoteTuple2Syntax(remote)
-
-  implicit def RemoteTuple3[A, B, C](remote: Remote[(A, B, C)]): RemoteTuple3Syntax[A, B, C] = new RemoteTuple3Syntax(
-    remote
-  )
-  implicit def RemoteTuple4[A, B, C, D](remote: Remote[(A, B, C, D)]): RemoteTuple4Syntax[A, B, C, D] =
-    new RemoteTuple4Syntax(remote)
-//
-//  implicit def RemoteTuple5[A, B, C, D, E](remote: Remote[(A, B, C, D, E)]): RemoteTuple5Syntax[A, B, C, D, E] =
-//    new RemoteTuple5Syntax(remote)
-
-  implicit def RemoteList[A](remote: Remote[List[A]]): RemoteListSyntax[A] = new RemoteListSyntax[A](remote)
-
-  implicit def RemoteOption[A](remote: Remote[Option[A]]): RemoteOptionSyntax[A] = new RemoteOptionSyntax[A](remote)
-
-  implicit def RemoteString(remote: Remote[String]): RemoteStringSyntax = new RemoteStringSyntax(remote)
-
-  implicit def RemoteExecutingFlow[A](remote: Remote[A]): RemoteExecutingFlowSyntax[A] =
-    new RemoteExecutingFlowSyntax[A](remote)
-
-  implicit def RemoteNumeric[A](remote: Remote[A]): RemoteNumericSyntax[A] = new RemoteNumericSyntax[A](remote)
-
-  implicit def RemoteRelational[A](remote: Remote[A]): RemoteRelationalSyntax[A] = new RemoteRelationalSyntax[A](remote)
-
-  implicit def RemoteFractional[A](remote: Remote[A]): RemoteFractionalSyntax[A] = new RemoteFractionalSyntax[A](remote)
-
-  implicit class ZFlowSyntax[R, E, A](flow: ZFlow[R, E, A]) {
-    def toRemote: Remote.Flow[R, E, A] = Remote.Flow(flow)
-  }
-
-  object RemoteVariableName extends Newtype[String]
+package object flow extends Syntax with Schemas {
   type RemoteVariableName = RemoteVariableName.Type
+  object RemoteVariableName extends Newtype[String] {
+    implicit val schema: Schema[RemoteVariableName] = Schema[String].transform(apply(_), unwrap)
+  }
 
   object FlowId extends Newtype[String]
   type FlowId = FlowId.Type

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteVariableSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteVariableSyntax.scala
@@ -20,7 +20,7 @@ import zio.flow._
 import zio.schema.Schema
 import zio.stream.ZNothing
 
-class RemoteVariableSyntax[A](val self: Remote[Remote.Variable[A]]) extends AnyVal {
+class RemoteVariableSyntax[A](val self: Remote[RemoteVariableReference[A]]) extends AnyVal {
   def get(implicit schema: Schema[A]): ZFlow[Any, ZNothing, A] = self.modify((a: Remote[A]) => (a, a))
 
   def set(a: Remote[A])(implicit schema: Schema[A]): ZFlow[Any, ZNothing, Unit] =

--- a/zio-flow/shared/src/test/scala/zio/flow/GoodcoverUseCase.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/GoodcoverUseCase.scala
@@ -10,7 +10,7 @@ import java.net.URI
 object GoodcoverUseCase extends ZIOSpecDefault {
 
   def setBoolVarAfterSleep(
-    remoteBoolVar: Remote[RemoteVariable[Boolean]],
+    remoteBoolVar: Remote[RemoteVariableReference[Boolean]],
     sleepDuration: Long,
     value: Boolean
   ): ZFlow[Any, ZNothing, Unit] = for {
@@ -77,7 +77,7 @@ object GoodcoverUseCase extends ZIOSpecDefault {
     ZFlow.unit
   )
 
-  def waitAndSetEvalDoneToTrue(evaluationDone: Remote[RemoteVariable[Boolean]]): ZFlow[Any, ZNothing, Unit] =
+  def waitAndSetEvalDoneToTrue(evaluationDone: Remote[RemoteVariableReference[Boolean]]): ZFlow[Any, ZNothing, Unit] =
     for {
       boolVar <- evaluationDone
       _       <- ZFlow.sleep(Remote.ofSeconds(3L))
@@ -85,7 +85,7 @@ object GoodcoverUseCase extends ZIOSpecDefault {
     } yield ()
 
   def manualEvalReminderFlow(
-    manualEvalDone: Remote[RemoteVariable[Boolean]]
+    manualEvalDone: Remote[RemoteVariableReference[Boolean]]
   ): ZFlow[Any, ActivityError, Boolean] = ZFlow.iterate(
     Remote(true),
     (_: Remote[Boolean]) => // TODO: could be eliminated by reenabling implicit R=>F conversion
@@ -103,7 +103,7 @@ object GoodcoverUseCase extends ZIOSpecDefault {
   )
 
   def policyPaymentReminderFlow(
-    renewPolicy: Remote[RemoteVariable[Boolean]]
+    renewPolicy: Remote[RemoteVariableReference[Boolean]]
   ): ZFlow[Any, ActivityError, Boolean] = ZFlow.iterate(
     Remote(true),
     (_: Remote[Boolean]) =>

--- a/zio-flow/shared/src/test/scala/zio/flow/internal/PersistentExecutorSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/internal/PersistentExecutorSpec.scala
@@ -234,7 +234,7 @@ object PersistentExecutorSpec extends ZIOFlowBaseSpec {
     } { (result: Exit[String, Nothing]) =>
       assert(result)(dies(hasMessage(equalTo("Could not evaluate ZFlow"))))
     }
-    // TODO: retryUntil, orTry, interrupt
+    // TODO: retryUntil, orTry
   )
 
   val suite2 = suite("Restarted flows")(

--- a/zio-flow/shared/src/test/scala/zio/flow/serialization/Generators.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/serialization/Generators.scala
@@ -11,6 +11,7 @@ import zio.flow.{
   Operation,
   Remote,
   RemoteVariableName,
+  RemoteVariableReference,
   SchemaAndValue,
   ZFlow,
   schemaZNothing
@@ -684,11 +685,11 @@ trait Generators extends DefaultJavaTimeSchemas {
   lazy val genZFlowModify: Gen[Random with Sized, ZFlow.Modify[Int, String]] =
     for {
       varName <- genRemoteVariableName
-      svar     = Remote.Variable(varName, Schema[Int])
+      svar     = RemoteVariableReference[Int](varName)
       f = Remote.RemoteFunction((a: Remote[Int]) =>
             Remote.Tuple2(Remote("done"), Remote.AddNumeric(a, Remote(1), Numeric.NumericInt))
           )
-    } yield ZFlow.Modify(svar, f.evaluated)(Schema[String])
+    } yield ZFlow.Modify(Remote(svar), f.evaluated)(Schema[String])
 
   lazy val genZFlowFold: Gen[Random with Sized, ZFlow.Fold[Any, Nothing, ZNothing, Instant, Any]] =
     for {

--- a/zio-flow/shared/src/test/scala/zio/flow/serialization/Generators.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/serialization/Generators.scala
@@ -774,10 +774,7 @@ trait Generators extends DefaultJavaTimeSchemas {
       flow     <- Gen.int.map(value => ZFlow.Return(Remote(value)).asInstanceOf[ZFlow[Any, Any, Any]])
       duration <- genDurationFromLong
     } yield ZFlow
-      .Timeout(flow, duration.asInstanceOf[Remote[Duration]])(
-        zio.flow.schemaZNothing.asInstanceOf[Schema[Any]],
-        Schema[Int].asInstanceOf[Schema[Any]]
-      )
+      .Timeout(flow, duration.asInstanceOf[Remote[Duration]])
       .asInstanceOf[ZFlow.Timeout[Any, Any, Any]]
 
   lazy val genZFlowProvide: Gen[Random with Sized, ZFlow.Provide[String, Nothing, String]] =

--- a/zio-flow/shared/src/test/scala/zio/flow/serialization/Generators.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/serialization/Generators.scala
@@ -689,7 +689,7 @@ trait Generators extends DefaultJavaTimeSchemas {
       f = Remote.RemoteFunction((a: Remote[Int]) =>
             Remote.Tuple2(Remote("done"), Remote.AddNumeric(a, Remote(1), Numeric.NumericInt))
           )
-    } yield ZFlow.Modify(Remote(svar), f.evaluated)(Schema[String])
+    } yield ZFlow.Modify(Remote(svar), f.evaluated)
 
   lazy val genZFlowFold: Gen[Random with Sized, ZFlow.Fold[Any, Nothing, ZNothing, Instant, Any]] =
     for {

--- a/zio-flow/shared/src/test/scala/zio/flow/serialization/Generators.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/serialization/Generators.scala
@@ -708,16 +708,6 @@ trait Generators extends DefaultJavaTimeSchemas {
       successSchemaAndValue.schema.asInstanceOf[Schema[Any]]
     )
 
-  lazy val genZFlowApply: Gen[Random with Sized, ZFlow[Any, Any, Any]] =
-    for {
-      resultFlow <- Gen.oneOf(genZFlowFold, genZFlowModify, genZFlowReturn)
-    } yield ZFlow
-      .Apply[Int, Nothing, Any](RemoteFunction((_: Remote[Int]) => resultFlow.toRemote).evaluated)(
-        zio.flow.schemaZNothing,
-        resultFlow.resultSchema.asInstanceOf[Schema[Any]]
-      )
-      .asInstanceOf[ZFlow[Any, Any, Any]]
-
   lazy val genZFlowLog: Gen[Random with Sized, ZFlow.Log] =
     Gen.string.map(ZFlow.Log(_))
 

--- a/zio-flow/shared/src/test/scala/zio/flow/serialization/Generators.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/serialization/Generators.scala
@@ -766,10 +766,7 @@ trait Generators extends DefaultJavaTimeSchemas {
     for {
       flow <- Gen.int.map(value => ZFlow.Return(Remote(value)).asInstanceOf[ZFlow[Any, Any, Any]])
     } yield ZFlow
-      .Fork(flow)(
-        schemaZNothing.asInstanceOf[Schema[Any]],
-        Schema[Int].asInstanceOf[Schema[Any]]
-      )
+      .Fork(flow)
       .asInstanceOf[ZFlow.Fork[Any, Any, Any]]
 
   lazy val genZFlowTimeout: Gen[Random with Sized, ZFlow.Timeout[Any, Any, Any]] =

--- a/zio-flow/shared/src/test/scala/zio/flow/serialization/ZFlowSerializationSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/serialization/ZFlowSerializationSpec.scala
@@ -34,7 +34,6 @@ object ZFlowSerializationSpec extends DefaultRunnableSpec with Generators {
       test("WaitTill")(roundtripCheck(codec, genZFlowWaitTill)),
       test("Modify")(roundtripCheck(codec, genZFlowModify)),
       test("Fold")(roundtripCheck(codec, genZFlowFold)),
-      test("Apply")(roundtripCheck(codec, genZFlowApply)),
       test("Log")(roundtripCheck(codec, genZFlowLog)),
       test("RunActivity")(roundtripCheck(codec, genZFlowRunActivity)),
       test("Transaction")(roundtripCheck(codec, genZFlowTransaction)),


### PR DESCRIPTION
- Separates `Remote.Variable` which is a type of `Remote` that when evaluated gets its value from a remote variable from `RemoteVariableReference` which just identifies such a remote variable in flows (result of `NewVar`, input of `Modify`) #145 
- Clean up some redundant schema capturing (part of #155)
