### PR TITLE
Reenable Scala.js support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,9 +41,9 @@ lazy val root = project
     dynamodb,
     docs,
     examplesJVM,
-//    examplesJS,
-    zioFlowJVM
-//    zioFlowJS
+    examplesJS,
+    zioFlowJVM,
+    zioFlowJS
   )
 
 lazy val zioFlow = crossProject(JSPlatform, JVMPlatform)
@@ -68,6 +68,7 @@ lazy val zioFlow = crossProject(JSPlatform, JVMPlatform)
 
 lazy val zioFlowJS = zioFlow.js
   .settings(scalaJSUseMainModuleInitializer := true)
+  .settings(fork := false)
 
 lazy val zioFlowJVM = zioFlow.jvm
 


### PR DESCRIPTION
Resolves https://github.com/zio/zio-flow/issues/156.

The `fork := false` setting is necessary due to [this](https://github.com/scala-js/scala-js/issues/1590) Scala.js behavior.