### PR TITLE
First API endpoint draft and required updates to the executor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,8 @@ inThisBuild(
         url("http://degoes.net")
       )
     ),
+    resolvers +=
+      "Sonatype OSS Snapshots" at "https://s01.oss.sonatype.org/content/repositories/snapshots",
     pgpPassphrase := sys.env.get("PGP_PASSWORD").map(_.toArray),
     pgpPublicRing := file("/tmp/public.asc"),
     pgpSecretRing := file("/tmp/secret.asc")
@@ -58,9 +60,13 @@ lazy val zioFlow = crossProject(JSPlatform, JVMPlatform)
       "dev.zio" %% "zio-schema-derivation" % Version.zioSchema,
       "dev.zio" %% "zio-schema-optics"     % Version.zioSchema,
       "dev.zio" %% "zio-schema-json"       % Version.zioSchema,
-      "dev.zio" %% "zio-schema-protobuf"   % Version.zioSchema
+      "dev.zio" %% "zio-schema-protobuf"   % Version.zioSchema,
+      "io.d11"  %% "zhttp"                 % Version.zioHttp
     ) ++
       commonTestDependencies.map(_ % Test)
+      ++ Seq(
+        "io.d11" %% "zhttp-test" % Version.zioHttp % Test
+      )
   )
   .settings(fork := true)
   .settings(testFrameworks += zioTest)

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -6,6 +6,7 @@ object Version {
 
   val zio                 = "2.0.0-RC6"
   val zioNio              = "2.0.0-RC7"
+  val zioHttp             = "2.0.0-RC7+1-c29b7875-SNAPSHOT"
   val zioAws              = "5.17.193.1"
   val zioRocksDb          = "0.4.0-RC3"
   val zioSchema           = "0.2.0-RC6"

--- a/zio-flow/shared/src/main/scala/zio/flow/internal/ZFlowExecutor.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/internal/ZFlowExecutor.scala
@@ -18,7 +18,7 @@ package zio.flow.internal
 
 import zio._
 import zio.flow.{FlowId, ZFlow}
-import zio.schema.Schema
+import zio.schema.{DynamicValue, Schema}
 
 import java.io.IOException
 
@@ -31,6 +31,25 @@ trait ZFlowExecutor {
    * result will be awaited.
    */
   def submit[E: Schema, A: Schema](id: FlowId, flow: ZFlow[Any, E, A]): IO[E, A]
+
+  /**
+   * Submits a flow to be executed and returns a durable promise that will
+   * complete when the flow completes.
+   *
+   * If the executor is already running a flow with the given ID, the existing
+   * flow's durable promise will be returned
+   */
+  def start[E, A](
+    id: FlowId,
+    flow: ZFlow[Any, E, A]
+  ): ZIO[Any, IOException, DurablePromise[Either[Throwable, DynamicValue], DynamicValue]]
+
+  /**
+   * Poll currently running and complete workflows.
+   *
+   * If the workflow with the provided id is completed, it will be returned.
+   */
+  def pollWorkflowDynTyped(id: FlowId): ZIO[Any, Exception, Option[IO[DynamicValue, DynamicValue]]]
 
   /**
    * Restart all known persisted running flows after recreating an executor.

--- a/zio-flow/shared/src/main/scala/zio/flow/package.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/package.scala
@@ -28,7 +28,12 @@ package object flow extends Syntax with Schemas {
     implicit val schema: Schema[RemoteVariableName] = Schema[String].transform(apply(_), unwrap)
   }
 
-  object FlowId extends Newtype[String]
+  object FlowId extends Newtype[String] {
+
+    def newRandom: ZIO[Any, Nothing, FlowId] =
+      Random.nextUUID.map(rid => FlowId.apply(rid.toString))
+
+  }
   type FlowId = FlowId.Type
 
   implicit class FlowIdSyntax(val flowId: FlowId) extends AnyVal {

--- a/zio-flow/shared/src/main/scala/zio/flow/server/RestMain.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/server/RestMain.scala
@@ -1,0 +1,12 @@
+package zio.flow.server
+
+import zhttp.service.Server
+import zio.{Scope, ZIO, ZIOAppArgs, ZIOAppDefault}
+
+object RestMain extends ZIOAppDefault {
+
+  val endpoint = WorkflowEndpoint.makeBroken()
+
+  val run: ZIO[Any with ZIOAppArgs with Scope, Throwable, Nothing] =
+    Server.start(8090, endpoint.endpoint)
+}

--- a/zio-flow/shared/src/main/scala/zio/flow/server/WorkflowEndpoint.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/server/WorkflowEndpoint.scala
@@ -1,0 +1,74 @@
+package zio.flow.server
+
+import zhttp.http.{Http, HttpApp, Method, Request, Response}
+import zhttp.http._
+import zio.ZIO
+import zio.flow.{FlowId, ZFlow}
+import zio.flow.internal.ZFlowExecutor
+import zio.flow.server.WorkflowEndpoint.jsonToZFlow
+import zio.schema.{DynamicValue, Schema}
+import zio.schema.codec.JsonCodec
+
+import java.nio.charset.StandardCharsets
+
+class WorkflowEndpoint(pExec: ZFlowExecutor) {
+
+  // Create HTTP route
+  val endpoint: HttpApp[Any, Nothing] = Http.collectZIO[Request] {
+    // Submit a job, return a UUID
+    case req @ Method.POST -> !! / "submit" =>
+      val fIdZ = for {
+        flow <- deserializeFlow(req)
+        fId  <- FlowId.newRandom
+        // is orDie smart here?
+        _ <- pExec.start(fId, flow).orDie
+      } yield fId
+
+      fIdZ.fold(e => Response.text("Ran into error: " + e), ok => Response.text(ok.toString))
+
+    // Poll for a result
+    case Method.GET -> !! / "poll" / uuid =>
+      val maybeResponse = pExec.pollWorkflowDynTyped(FlowId(uuid)).flatMap {
+        case None =>
+          // Job not done yet, nothing to return
+          ZIO.succeed(Response.text("Come back later"))
+        case Some(r) =>
+          // We have a result: serialize and send back.
+          // TODO should we have a class that will convey success/failure information?
+          r.fold(
+            err =>
+              // TODO convey back that it's a failure?
+              JsonCodec.encode(Schema[DynamicValue])(err),
+            ok =>
+              // TODO convey back that it's a success?
+              JsonCodec.encode(Schema[DynamicValue])(ok)
+          ).map(bytes => Response.json(new String(bytes.toArray, StandardCharsets.UTF_8)))
+      }
+
+      maybeResponse.fold(
+        e => Response.text("Ran into an error while checking for a result: " + e),
+        ok => ok
+      )
+  }
+
+  def deserializeFlow(r: Request) =
+    for {
+      payload <- r.body
+      zFlow <- ZIO
+                 .fromEither(jsonToZFlow(payload))
+                 // TODO custom error type? ;)
+                 .mapError(str => new Exception(str))
+    } yield zFlow
+}
+
+object WorkflowEndpoint {
+
+  def jsonToZFlow = JsonCodec.decode(ZFlow.schemaAny)
+
+  def make(): ZIO[ZFlowExecutor, Nothing, WorkflowEndpoint] =
+    for {
+      pExec <- ZIO.environmentWith[ZFlowExecutor](_.get)
+    } yield new WorkflowEndpoint(pExec)
+
+  def makeBroken() = new WorkflowEndpoint(null)
+}

--- a/zio-flow/shared/src/test/scala/zio/flow/server/WorkflowEndpointSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/server/WorkflowEndpointSpec.scala
@@ -1,0 +1,18 @@
+package zio.flow.server
+
+import zio.{Scope, ZLayer}
+import zio.flow.ZIOFlowBaseSpec
+import zio.flow.utils.MockExecutors
+import zio.test.{Spec, TestEnvironment, assertTrue}
+
+object WorkflowEndpointSpec extends ZIOFlowBaseSpec {
+
+  override def spec: Spec[TestEnvironment with Scope, Any] = suite("TODO")(
+    test("TODO")(assertTrue(true))
+  )
+
+  val exec = ZLayer.fromZIO(MockExecutors.mockPersistentTestClock)
+
+  val endpointLayer = exec >+> ZLayer.fromZIO(WorkflowEndpoint.make())
+
+}

--- a/zio-flow/shared/src/test/scala/zio/flow/utils/MockExecutors.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/utils/MockExecutors.scala
@@ -43,5 +43,7 @@ object MockExecutors {
       )
       .build
       .map(_.get[ZFlowExecutor])
+
   }
+
 }


### PR DESCRIPTION
For Issue: https://github.com/zio/zio-flow/issues/183

## PR Status

This is parked for now, some details on the status:

The commented out unit test fails, as the result that is expected to be found when polling does not seem to be completed when it actually should.

The unit test that polls for the result of a simple flow succeeds.

I see two possible explanations for this:
 - It is due to some things I don't know about the testing in conjunction with ZIO.sleep, Clocks and the environment
 - Polling is currently broken because of the underlying implementation of how results are retrieved. A cursory look indicates that some `Hub`s are involved, and if we subscribe to the hub after the result is published, we’ll miss it.