### PR TITLE
Clean up Remotes

### DIFF
--- a/zio-flow/shared/src/main/scala/zio/flow/ExecutingFlow.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/ExecutingFlow.scala
@@ -1,30 +1,15 @@
 package zio.flow
 
-import zio.Fiber
 import zio.flow.internal.DurablePromise
 import zio.schema.Schema
 
-sealed trait ExecutingFlow[+E, +A]
+final case class ExecutingFlow[+E, +A](id: FlowId, result: DurablePromise[_, _])
 
 object ExecutingFlow {
-  final case class InMemoryExecutingFlow[+E, +A](fiber: Fiber[E, A])                         extends ExecutingFlow[E, A]
-  final case class PersistentExecutingFlow[+E, +A](id: FlowId, result: DurablePromise[_, _]) extends ExecutingFlow[E, A]
-
-  object PersistentExecutingFlow {
-    def schema[E, A]: Schema[PersistentExecutingFlow[E, A]] =
-      (Schema[String] zip Schema[DurablePromise[Either[Throwable, E], A]]).transform(
-        { case (id, promise) => PersistentExecutingFlow(FlowId(id), promise) },
-        (ef: PersistentExecutingFlow[E, A]) =>
-          (FlowId.unwrap(ef.id), ef.result.asInstanceOf[DurablePromise[Either[Throwable, E], A]])
-      )
-  }
-
   implicit def schema[E, A]: Schema[ExecutingFlow[E, A]] =
-    Schema.Enum1[PersistentExecutingFlow[E, A], ExecutingFlow[E, A]](
-      Schema.Case[PersistentExecutingFlow[E, A], ExecutingFlow[E, A]](
-        "PersistentExecutingFlow",
-        PersistentExecutingFlow.schema[E, A],
-        _.asInstanceOf[PersistentExecutingFlow[E, A]]
-      )
+    (Schema[String] zip Schema[DurablePromise[Either[Throwable, E], A]]).transform(
+      { case (id, promise) => ExecutingFlow(FlowId(id), promise) },
+      (ef: ExecutingFlow[E, A]) =>
+        (FlowId.unwrap(ef.id), ef.result.asInstanceOf[DurablePromise[Either[Throwable, E], A]])
     )
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/Mappable.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/Mappable.scala
@@ -34,7 +34,7 @@ object Mappable {
       fa: Remote[Option[A]],
       ab: Remote[A] => Remote[B]
     ): Remote[Option[B]] =
-      Remote.FoldOption(fa, Remote(None), RemoteFunction((a: Remote[A]) => Remote.Some0(ab(a))).evaluated)
+      Remote.FoldOption(fa, Remote(None), RemoteFunction((a: Remote[A]) => Remote.RemoteSome(ab(a))).evaluated)
 
     override def performFilter[A: Schema](
       fa: Remote[Option[A]],

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteBooleanSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteBooleanSyntax.scala
@@ -19,19 +19,19 @@ package zio.flow.remote
 import zio.flow.Remote
 import zio.schema.Schema
 
-class RemoteBooleanSyntax(val self: Remote[Boolean]) {
+final class RemoteBooleanSyntax(val self: Remote[Boolean]) extends AnyVal {
 
-  final def not: Remote[Boolean] = Remote.Not(self)
+  def not: Remote[Boolean] = Remote.Not(self)
 
-  final def &&(that: Remote[Boolean]): Remote[Boolean] =
+  def &&(that: Remote[Boolean]): Remote[Boolean] =
     Remote.And(self, that)
 
-  final def ||(that: Remote[Boolean]): Remote[Boolean] =
+  def ||(that: Remote[Boolean]): Remote[Boolean] =
     (not && that.not).not
 
-  final def ifThenElse[B: Schema](ifTrue: Remote[B], ifFalse: Remote[B]): Remote[B] =
+  def ifThenElse[B: Schema](ifTrue: Remote[B], ifFalse: Remote[B]): Remote[B] =
     Remote.Branch(self, Remote.suspend(ifTrue), Remote.suspend(ifFalse))
 
-  final def unary_! : Remote[Boolean] =
+  def unary_! : Remote[Boolean] =
     not
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteDurationSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteDurationSyntax.scala
@@ -21,7 +21,7 @@ import zio.flow._
 import java.time.temporal.ChronoUnit
 import java.time.{Duration, Instant}
 
-class RemoteDurationSyntax(val self: Remote[Duration]) extends AnyVal {
+final class RemoteDurationSyntax(val self: Remote[Duration]) extends AnyVal {
 
   def isZero: Remote[Boolean]     = self.getSeconds === 0L && self.getNano === 0L
   def isNegative: Remote[Boolean] = self.getSeconds < 0L
@@ -41,7 +41,7 @@ class RemoteDurationSyntax(val self: Remote[Duration]) extends AnyVal {
   def plusNanos(nanoToAdd: Remote[Long]): Remote[Duration]      = plus(Remote.ofNanos(nanoToAdd))
 
   def minus(that: Remote[Duration]): Remote[Duration] =
-    Remote.DurationMinusDuration(self, that)
+    Remote.DurationPlusDuration(self, that.multipliedBy(-1L))
 
   def minus(amountToSubtract: Remote[Long], temporalUnit: Remote[ChronoUnit]): Remote[Duration] =
     minus(Remote.DurationFromAmount(amountToSubtract, temporalUnit))
@@ -51,6 +51,8 @@ class RemoteDurationSyntax(val self: Remote[Duration]) extends AnyVal {
   def minusMinutes(minutesToSubtract: Remote[Long]): Remote[Duration] = minus(Remote.ofMinutes(minutesToSubtract))
   def minusSeconds(secondsToSubtract: Remote[Long]): Remote[Duration] = minus(Remote.ofSeconds(secondsToSubtract))
   def minusNanos(nanosToSubtract: Remote[Long]): Remote[Duration]     = minus(Remote.ofNanos(nanosToSubtract))
+
+  def multipliedBy(amount: Remote[Long]): Remote[Duration] = Remote.DurationMultipliedBy(self, amount)
 }
 
 object RemoteDuration {

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteExecutingFlowSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteExecutingFlowSyntax.scala
@@ -16,12 +16,10 @@
 
 package zio.flow.remote
 
-import zio.flow.{ActivityError, ExecutingFlow, FlowId, Remote, ZFlow}
+import zio.flow.{ActivityError, ExecutingFlow, Remote, ZFlow}
 import zio.schema.Schema
 
-class RemoteExecutingFlowSyntax[E, A](self: Remote[ExecutingFlow[E, A]]) {
-
-  def flowId: Remote[FlowId] = ???
+final class RemoteExecutingFlowSyntax[E, A](val self: Remote[ExecutingFlow[E, A]]) extends AnyVal {
 
   def await(implicit schemaE: Schema[E], schemaA: Schema[A]): ZFlow[Any, ActivityError, Either[E, A]] =
     ZFlow.Await(self)

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteFractionalSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteFractionalSyntax.scala
@@ -17,30 +17,31 @@
 package zio.flow.remote
 
 import zio.flow._
+import zio.flow.remote.numeric._
 import zio.schema.Schema
 
-class RemoteFractionalSyntax[A](self: Remote[A]) {
+final class RemoteFractionalSyntax[A](val self: Remote[A]) extends AnyVal {
 
-  final def sin(implicit fractional: Fractional[A]): Remote[A] =
-    Remote.SinFractional(self, fractional)
+  def sin(implicit fractional: Fractional[A]): Remote[A] =
+    Remote.UnaryFractional(self, fractional, UnaryFractionalOperator.Sin)
 
-  final def cos(implicit fractional: Fractional[A]): Remote[A] = {
+  def cos(implicit fractional: Fractional[A]): Remote[A] = {
     implicit val schemaA1: Schema[A] = fractional.schema
     Remote(fractional.fromDouble(1.0)) - sin(fractional) pow Remote(fractional.fromDouble(2.0))
   }
 
-  final def tan(implicit fractional: Fractional[A]): Remote[A] =
+  def tan(implicit fractional: Fractional[A]): Remote[A] =
     sin(fractional) / cos(fractional)
 
-  final def sinInverse(implicit fractional: Fractional[A]): Remote[A] =
-    Remote.SinInverseFractional(self, fractional)
+  def asin(implicit fractional: Fractional[A]): Remote[A] =
+    Remote.UnaryFractional(self, fractional, UnaryFractionalOperator.ArcSin)
 
-  final def cosInverse(implicit fractional: Fractional[A]): Remote[A] = {
+  def acos(implicit fractional: Fractional[A]): Remote[A] = {
     implicit val schema = fractional.schema
-    Remote(fractional.fromDouble(1.571)) - sinInverse(fractional)
+    Remote(fractional.fromDouble(1.571)) - asin(fractional)
   }
 
-  final def tanInverse(implicit fractional: Fractional[A]): Remote[A] =
-    Remote.TanInverseFractional(self, fractional)
+  def atan(implicit fractional: Fractional[A]): Remote[A] =
+    Remote.UnaryFractional(self, fractional, UnaryFractionalOperator.ArcTan)
 
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteInstantSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteInstantSyntax.scala
@@ -21,7 +21,7 @@ import zio.flow._
 import java.time.temporal.ChronoUnit
 import java.time.{Duration, Instant}
 
-class RemoteInstantSyntax(val self: Remote[Instant]) extends AnyVal {
+final class RemoteInstantSyntax(val self: Remote[Instant]) extends AnyVal {
 
   def isAfter(that: Remote[Instant]): Remote[Boolean]  = self.getEpochSecond > that.getEpochSecond
   def isBefore(that: Remote[Instant]): Remote[Boolean] = self.getEpochSecond < that.getEpochSecond
@@ -47,7 +47,7 @@ class RemoteInstantSyntax(val self: Remote[Instant]) extends AnyVal {
     self.plus(nanoSecondsToAdd, Remote(ChronoUnit.NANOS))
 
   def minusDuration(duration: Remote[Duration]): Remote[Instant] =
-    Remote.InstantMinusDuration(self, duration)
+    self.plusDuration(duration.multipliedBy(-1L))
 
   def minus(amountToSubtract: Remote[Long], unit: Remote[ChronoUnit]): Remote[Instant] =
     self.minusDuration(Remote.DurationFromAmount(amountToSubtract, unit))

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteMappableSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteMappableSyntax.scala
@@ -19,7 +19,7 @@ package zio.flow.remote
 import zio.flow.{Mappable, Remote, RemoteContext}
 import zio.schema.Schema
 
-class RemoteMappableSyntax[A](self: Remote[A]) {
+final class RemoteMappableSyntax[A](val self: Remote[A]) extends AnyVal {
 
   def filter[F[_], A1: Schema](
     predicate: Remote[A1] => Remote[Boolean]

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteNumericSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteNumericSyntax.scala
@@ -17,51 +17,55 @@
 package zio.flow.remote
 
 import zio.flow._
+import zio.flow.remote.numeric._
 
 class RemoteNumericSyntax[A](self: Remote[A]) {
 
   final def +(that: Remote[A])(implicit numeric: Numeric[A]): Remote[A] =
-    Remote.AddNumeric(self.widen[A], that, numeric)
+    Remote.BinaryNumeric(self.widen[A], that, numeric, BinaryNumericOperator.Add)
 
   final def /(that: Remote[A])(implicit numeric: Numeric[A]): Remote[A] =
-    Remote.DivNumeric(self.widen[A], that, numeric)
+    Remote.BinaryNumeric(self.widen[A], that, numeric, BinaryNumericOperator.Div)
+
+  final def %(that: Remote[A])(implicit numeric: Numeric[A]): Remote[A] =
+    mod(that)
 
   final def *(that: Remote[A])(implicit numeric: Numeric[A]): Remote[A] =
-    Remote.MulNumeric(self.widen[A], that, numeric)
+    Remote.BinaryNumeric(self.widen[A], that, numeric, BinaryNumericOperator.Mul)
 
   final def unary_-(implicit numeric: Numeric[A]): Remote[A] =
-    Remote.NegationNumeric(self.widen[A], numeric)
+    Remote.UnaryNumeric(self.widen[A], numeric, UnaryNumericOperator.Neg)
 
   final def -(that: Remote[A])(implicit numeric: Numeric[A]): Remote[A] =
-    Remote.AddNumeric(self.widen[A], -that, numeric)
+    Remote.BinaryNumeric(self.widen[A], -that, numeric, BinaryNumericOperator.Add)
 
   final def pow(exp: Remote[A])(implicit numeric: Numeric[A]): Remote[A] =
-    Remote.PowNumeric(self.widen[A], exp, numeric)
+    Remote.BinaryNumeric(self.widen[A], exp, numeric, BinaryNumericOperator.Pow)
 
   final def root(n: Remote[A])(implicit numeric: Numeric[A]): Remote[A] =
-    Remote.RootNumeric(self.widen[A], n, numeric)
+    Remote.BinaryNumeric(self.widen[A], n, numeric, BinaryNumericOperator.Root)
 
   final def log(base: Remote[A])(implicit numeric: Numeric[A]): Remote[A] =
-    Remote.LogNumeric(self.widen[A], base, numeric)
+    Remote.BinaryNumeric(self.widen[A], base, numeric, BinaryNumericOperator.Log)
 
-  final def mod(that: Remote[Int])(implicit ev: A <:< Int, numericInt: Numeric[Int]): Remote[Int] =
-    Remote.ModNumeric(self.widen[Int], that)
+  final def mod(that: Remote[A])(implicit numeric: Numeric[A]): Remote[A] =
+    Remote.BinaryNumeric(self, that, numeric, BinaryNumericOperator.Mod)
 
   final def abs(implicit numeric: Numeric[A]): Remote[A] =
-    Remote.AbsoluteNumeric(self.widen[A], numeric)
+    Remote.UnaryNumeric(self.widen[A], numeric, UnaryNumericOperator.Abs)
 
   final def min(that: Remote[A])(implicit numeric: Numeric[A]): Remote[A] =
-    Remote.MinNumeric(self.widen[A], that, numeric)
+    Remote.BinaryNumeric(self.widen[A], that, numeric, BinaryNumericOperator.Min)
 
   final def max(that: Remote[A])(implicit numeric: Numeric[A]): Remote[A] =
-    Remote.MaxNumeric(self.widen[A], that, numeric)
+    Remote.BinaryNumeric(self.widen[A], that, numeric, BinaryNumericOperator.Max)
 
   final def floor(implicit numeric: Numeric[A]): Remote[A] =
-    Remote.FloorNumeric(self.widen[A], numeric)
+    Remote.UnaryNumeric(self.widen[A], numeric, UnaryNumericOperator.Floor)
 
   final def ceil(implicit numeric: Numeric[A]): Remote[A] =
-    Remote.CeilNumeric(self.widen[A], numeric)
+    Remote.UnaryNumeric(self.widen[A], numeric, UnaryNumericOperator.Ceil)
 
   final def round(implicit numeric: Numeric[A]): Remote[A] =
-    Remote.RoundNumeric(self.widen[A], numeric)
+    Remote.UnaryNumeric(self.widen[A], numeric, UnaryNumericOperator.Round)
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteRelationalSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteRelationalSyntax.scala
@@ -18,23 +18,23 @@ package zio.flow.remote
 
 import zio.flow._
 
-class RemoteRelationalSyntax[A](self: Remote[A]) {
+final class RemoteRelationalSyntax[A](val self: Remote[A]) extends AnyVal {
 
-  final def <(that: Remote[A]): Remote[Boolean] =
+  def <(that: Remote[A]): Remote[Boolean] =
     (self <= that) && (self !== that)
 
-  final def <=(that: Remote[A]): Remote[Boolean] =
+  def <=(that: Remote[A]): Remote[Boolean] =
     Remote.LessThanEqual(self, that)
 
-  final def >(that: Remote[A]): Remote[Boolean] =
+  def >(that: Remote[A]): Remote[Boolean] =
     !(self <= that)
 
-  final def >=(that: Remote[A]): Remote[Boolean] =
+  def >=(that: Remote[A]): Remote[Boolean] =
     (self > that) || (self === that)
 
-  final def !==(that: Remote[A]): Remote[Boolean] =
+  def !==(that: Remote[A]): Remote[Boolean] =
     !(self === that)
 
-  final def ===(that: Remote[A]): Remote[Boolean] =
+  def ===(that: Remote[A]): Remote[Boolean] =
     Remote.Equal(self, that)
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteStringSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteStringSyntax.scala
@@ -18,6 +18,6 @@ package zio.flow.remote
 
 import zio.flow._
 
-class RemoteStringSyntax(self: Remote[String]) {
+final class RemoteStringSyntax(val self: Remote[String]) extends AnyVal {
   def length: Remote[Int] = Remote.Length(self)
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/numeric/BinaryNumericOperator.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/numeric/BinaryNumericOperator.scala
@@ -1,0 +1,18 @@
+package zio.flow.remote.numeric
+
+import zio.schema.{DeriveSchema, Schema}
+
+sealed trait BinaryNumericOperator
+object BinaryNumericOperator {
+  case object Add  extends BinaryNumericOperator
+  case object Mul  extends BinaryNumericOperator
+  case object Div  extends BinaryNumericOperator
+  case object Mod  extends BinaryNumericOperator
+  case object Pow  extends BinaryNumericOperator
+  case object Root extends BinaryNumericOperator
+  case object Log  extends BinaryNumericOperator
+  case object Min  extends BinaryNumericOperator
+  case object Max  extends BinaryNumericOperator
+
+  implicit val schema: Schema[BinaryNumericOperator] = DeriveSchema.gen
+}

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/numeric/UnaryFractionalOperator.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/numeric/UnaryFractionalOperator.scala
@@ -1,0 +1,12 @@
+package zio.flow.remote.numeric
+
+import zio.schema.{DeriveSchema, Schema}
+
+sealed trait UnaryFractionalOperator
+object UnaryFractionalOperator {
+  case object Sin    extends UnaryFractionalOperator
+  case object ArcSin extends UnaryFractionalOperator
+  case object ArcTan extends UnaryFractionalOperator
+
+  implicit val schema: Schema[UnaryFractionalOperator] = DeriveSchema.gen
+}

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/numeric/UnaryNumericOperator.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/numeric/UnaryNumericOperator.scala
@@ -1,0 +1,14 @@
+package zio.flow.remote.numeric
+
+import zio.schema.{DeriveSchema, Schema}
+
+sealed trait UnaryNumericOperator
+object UnaryNumericOperator {
+  case object Neg   extends UnaryNumericOperator
+  case object Abs   extends UnaryNumericOperator
+  case object Floor extends UnaryNumericOperator
+  case object Ceil  extends UnaryNumericOperator
+  case object Round extends UnaryNumericOperator
+
+  implicit val schema: Schema[UnaryNumericOperator] = DeriveSchema.gen
+}

--- a/zio-flow/shared/src/test/scala/zio/flow/internal/PersistentExecutorSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/internal/PersistentExecutorSpec.scala
@@ -50,14 +50,14 @@ object PersistentExecutorSpec extends ZIOFlowBaseSpec {
     testFlow("foldM - success side") {
       ZFlow
         .succeed(15)
-        .foldM(_ => ZFlow.unit, _ => ZFlow.unit)
+        .foldFlow(_ => ZFlow.unit, _ => ZFlow.unit)
     } { result =>
       assertTrue(result == unit)
     },
     testFlow("foldM - error side") {
       ZFlow
         .fail(15)
-        .foldM(_ => ZFlow.unit, _ => ZFlow.unit)
+        .foldFlow(_ => ZFlow.unit, _ => ZFlow.unit)
     } { result =>
       assertTrue(result == unit)
     },

--- a/zio-flow/shared/src/test/scala/zio/flow/remote/FractionalSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/remote/FractionalSpec.scala
@@ -18,16 +18,16 @@ object FractionalSpec extends RemoteSpecBase {
     ).provideCustom(ZLayer(RemoteContext.inMemory))
 
   private def fractionalTests[R, A: Schema](name: String, gen: Gen[R, A])(ops: FractionalOps[A])(implicit
-    fractionalA: remote.Fractional[A]
+    fractionalA: remote.numeric.Fractional[A]
   ) =
     suite(name)(
       testOp[R, A]("Sin", gen)(_.sin)(ops.sin),
       testOp[R, A]("Cos", gen)(_.cos)(ops.cos) @@ TestAspect.ignore,
       testOp[R, A]("Tan", gen)(_.tan)(ops.tan) @@ TestAspect.ignore,
-      testOp[R, A]("Tan-Inverse", gen)(_.tanInverse)(ops.inverseTan)
+      testOp[R, A]("Tan-Inverse", gen)(_.atan)(ops.inverseTan)
     )
 
-  private def testOp[R, A: Schema: remote.Fractional](name: String, gen: Gen[R, A])(
+  private def testOp[R, A: Schema: remote.numeric.Fractional](name: String, gen: Gen[R, A])(
     fractionalOp: Remote[A] => Remote[A]
   )(op: A => A): Spec[R with TestConfig with RemoteContext, Nothing] =
     test(name) {

--- a/zio-flow/shared/src/test/scala/zio/flow/remote/NumericSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/remote/NumericSpec.scala
@@ -3,6 +3,7 @@ package zio.flow.remote
 import zio.ZLayer
 import zio.flow.utils.RemoteAssertionSyntax._
 import zio.flow._
+import zio.flow.remote.numeric._
 import zio.schema.Schema
 import zio.test.{Gen, Spec, TestAspect, TestConfig, TestSuccess, check}
 
@@ -24,7 +25,7 @@ object NumericSpec extends RemoteSpecBase {
       )
     ).provideCustom(ZLayer(RemoteContext.inMemory))
 
-  private def numericTests[R, A: Schema: remote.Numeric](name: String, gen: Gen[R, A])(
+  private def numericTests[R, A: Schema: remote.numeric.Numeric](name: String, gen: Gen[R, A])(
     ops: NumericOps[A]
   ): Spec[R with TestConfig with RemoteContext, TestSuccess] =
     suite(name)(
@@ -44,7 +45,7 @@ object NumericSpec extends RemoteSpecBase {
 
   // TODO: BigDecimal fails Log/Root specs.
   //  It also fails Subtraction on 2.11 and 2.12.
-  private def numericTestsWithoutLogOrRoot[R, A: Schema: remote.Numeric](name: String, gen: Gen[R, A])(
+  private def numericTestsWithoutLogOrRoot[R, A: Schema: Numeric](name: String, gen: Gen[R, A])(
     ops: NumericOps[A]
   ) =
     suite(name)(
@@ -64,7 +65,7 @@ object NumericSpec extends RemoteSpecBase {
 //      testOp[R, A]("Root", gen, gen)(_ root _)(ops.root)
     )
 
-  private def testOp[R, A: Schema: remote.Numeric](name: String, genX: Gen[R, A], genY: Gen[R, A])(
+  private def testOp[R, A: Schema: Numeric](name: String, genX: Gen[R, A], genY: Gen[R, A])(
     numericOp: (Remote[A], Remote[A]) => Remote[A]
   )(op: (A, A) => A): Spec[R with TestConfig with RemoteContext, Nothing] =
     test(name) {
@@ -73,7 +74,7 @@ object NumericSpec extends RemoteSpecBase {
       }
     }
 
-  private def testOp[R, A: Schema: remote.Numeric](name: String, gen: Gen[R, A])(
+  private def testOp[R, A: Schema: Numeric](name: String, gen: Gen[R, A])(
     numericOp: Remote[A] => Remote[A]
   )(op: A => A): Spec[R with TestConfig with RemoteContext, Nothing] =
     test(name) {

--- a/zio-flow/shared/src/test/scala/zio/flow/remote/RemoteEitherSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/remote/RemoteEitherSpec.scala
@@ -13,7 +13,7 @@ object RemoteEitherSpec extends RemoteSpecBase {
       test("handleEither") {
         check(Gen.either(Gen.int, Gen.boolean)) { either =>
           val expected = either.fold(_ * 2, if (_) 10 else 20)
-          val result   = Remote(either).handleEither(_ * 2, _.ifThenElse(10, 20))
+          val result   = Remote(either).fold(_ * 2, _.ifThenElse(10, 20))
           result <-> expected
         }
       },

--- a/zio-flow/shared/src/test/scala/zio/flow/remote/RemoteOptionSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/remote/RemoteOptionSpec.scala
@@ -10,12 +10,12 @@ object RemoteOptionSpec extends RemoteSpecBase {
     suite("RemoteOptionSpec")(
       test("HandleOption for Some") {
         val option: Remote[Option[Int]] = Remote(Option(12))
-        val optionHandled: Remote[Int]  = option.handleOption(Remote(0), (x: Remote[Int]) => x * 2)
+        val optionHandled: Remote[Int]  = option.fold(Remote(0), (x: Remote[Int]) => x * 2)
         optionHandled <-> 24
       },
       test("HandleOption for None") {
         val option        = Remote[Option[Int]](None)
-        val optionHandled = option.handleOption(Remote(0), (x: Remote[Int]) => x * 2)
+        val optionHandled = option.fold(Remote(0), (x: Remote[Int]) => x * 2)
         optionHandled <-> 0
       },
       test("isSome") {
@@ -103,7 +103,7 @@ object RemoteOptionSpec extends RemoteSpecBase {
           )
           .map(TestResult.all(_: _*))
       },
-      test("OptionSpec") {
+      test("zip") {
         val op1 = Remote[Option[Int]](None)
         val op2 = Remote(Option(12))
         val op3 = Remote(Option(10))

--- a/zio-flow/shared/src/test/scala/zio/flow/serialization/RemoteSerializationSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/serialization/RemoteSerializationSpec.scala
@@ -73,27 +73,12 @@ object RemoteSerializationSpec extends ZIOSpecDefault with Generators {
         val variable = Remote.Variable[ZNothing](RemoteVariableName("test"), schemaZNothing)
         roundtrip(codec, variable)
       },
-      test("add numeric")(roundtripCheck(codec, genAddNumeric)),
-      test("div numeric")(roundtripCheck(codec, genDivNumeric)),
-      test("mul numeric")(roundtripCheck(codec, genMulNumeric)),
-      test("pow numeric")(roundtripCheck(codec, genPowNumeric)),
-      test("negation numeric")(roundtripCheck(codec, genNegationNumeric)),
-      test("root numeric")(roundtripCheck(codec, genRootNumeric)),
-      test("log numeric")(roundtripCheck(codec, genLogNumeric)),
-      test("absolute numeric")(roundtripCheck(codec, genAbsoluteNumeric)),
-      test("mod numeric")(roundtripCheck(codec, genModNumeric)),
-      test("min numeric")(roundtripCheck(codec, genMinNumeric)),
-      test("max numeric")(roundtripCheck(codec, genMaxNumeric)),
-      test("floor numeric")(roundtripCheck(codec, genFloorNumeric)),
-      test("ceil numeric")(roundtripCheck(codec, genCeilNumeric)),
-      test("round numeric")(roundtripCheck(codec, genRoundNumeric)),
-      test("sin fractional")(roundtripCheck(codec, genSinFractional)),
-      test("sin inverse fractional")(roundtripCheck(codec, genSinInverseFractional)),
-      test("tan inverse fractional")(roundtripCheck(codec, genTanInverseFractional)),
+      test("binary numeric")(roundtripCheck(codec, genBinaryNumeric)),
+      test("unary numeric")(roundtripCheck(codec, genUnaryNumeric)),
+      test("unary fractional")(roundtripCheck(codec, genUnaryFractional)),
       test("evaluated remote function")(roundtripCheck(codec, genEvaluatedRemoteFunction)),
       test("remote apply")(roundtripCheck(codec, genRemoteApply)),
-      test("either0")(roundtripCheck(codec, genEither0)),
-      test("flatMapEither")(roundtripCheck(codec, genFlatMapEither)),
+      test("remote either")(roundtripCheck(codec, genRemoteEither)),
       test("foldEither")(roundtripCheck(codec, genFoldEither)),
       test("swapEither")(roundtripCheck(codec, genSwapEither)),
       test("try")(roundtripCheck(codec, genTry)),
@@ -110,26 +95,19 @@ object RemoteSerializationSpec extends ZIOSpecDefault with Generators {
       test("fold")(roundtripCheck(codec, genFold)),
       test("cons")(roundtripCheck(codec, genCons)),
       test("uncons")(roundtripCheck(codec, genUnCons)),
-      test("instant from long")(roundtripCheck(codec, genInstantFromLong)),
       test("instant from longs")(roundtripCheck(codec, genInstantFromLongs)),
-      test("instant from milli")(roundtripCheck(codec, genInstantFromMilli)),
       test("instant from string")(roundtripCheck(codec, genInstantFromString)),
       test("instant to tuple")(roundtripCheck(codec, genInstantToTuple)),
       test("instant plus duration")(roundtripCheck(codec, genInstantPlusDuration)),
-      test("instant minus duration")(roundtripCheck(codec, genInstantMinusDuration)),
       test("duration from string")(roundtripCheck(codec, genDurationFromString)),
-      test("duration from long")(roundtripCheck(codec, genDurationFromLong)),
       test("duration from longs")(roundtripCheck(codec, genDurationFromLongs)),
       test("duration from big decimal")(roundtripCheck(codec, genDurationFromBigDecimal)),
       test("duration to longs")(roundtripCheck(codec, genDurationToLongs)),
-      test("duration to long")(roundtripCheck(codec, genDurationToLong)),
       test("duration plus duration")(roundtripCheck(codec, genDurationPlusDuration)),
-      test("duration minus duration")(roundtripCheck(codec, genDurationMinusDuration)),
+      test("duration multiplied by")(roundtripCheck(codec, genDurationMultipledBy)),
       test("iterate")(roundtripCheck(codec, genIterate)),
-      test("some0")(roundtripCheck(codec, genSome0)),
-      test("fold option")(roundtripCheck(codec, genFoldOption)),
-      test("zip option")(roundtripCheck(codec, genZipOption)),
-      test("option contains")(roundtripCheck(codec, genOptionContains))
+      test("remote some")(roundtripCheck(codec, genRemoteSome)),
+      test("fold option")(roundtripCheck(codec, genFoldOption))
     )
 
   private def evalWithCodec(codec: Codec): Spec[Sized with TestConfig, String] =
@@ -194,7 +172,7 @@ object RemoteSerializationSpec extends ZIOSpecDefault with Generators {
       },
       test("literal user type wrapped in Some") {
         check(TestCaseClass.gen) { data =>
-          val literal = Remote.Some0(Remote(data))
+          val literal = Remote.RemoteSome(Remote(data))
           roundtripEval(codec, literal).provide(ZLayer(RemoteContext.inMemory))
         }
       }

--- a/zio-flow/shared/src/test/scala/zio/flow/serialization/ZFlowSerializationSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/serialization/ZFlowSerializationSpec.scala
@@ -52,8 +52,7 @@ object ZFlowSerializationSpec extends ZIOSpecDefault with Generators {
       test("Interrupt")(roundtripCheck(codec, genZFlowInterrupt)),
       test("NewVar")(roundtripCheck(codec, genZFlowNewVar)),
       test("Fail")(roundtripCheck(codec, genZFlowFail)),
-      test("Iterate")(roundtripCheck(codec, genZFlowIterate)),
-      test("GetExecutionEnvironment")(roundtripCheck(codec, genZFlowGetExecutionEnvironment))
+      test("Iterate")(roundtripCheck(codec, genZFlowIterate))
     )
 
   private def roundtripCheck(


### PR DESCRIPTION
Reduces the number of `Remote` constructors (#149) by 21
(also related to #155)