### PR TITLE
Support timestamps in DynamoDbKeyValueStore

### DIFF
--- a/dynamodb/src/it/scala/zio/flow/dynamodb/DynamoDbKeyValueStoreSpec.scala
+++ b/dynamodb/src/it/scala/zio/flow/dynamodb/DynamoDbKeyValueStoreSpec.scala
@@ -1,151 +1,151 @@
-// TODO
-//package zio.flow.dynamodb
-//
-//import DynamoDbKeyValueStore.tableName
-//import DynamoDbSupport.{createDynamoDbTable, dynamoDbLayer}
-//import zio.flow.internal.KeyValueStore
-//import zio.{Chunk, ZIO}
-//import zio.test.Assertion.hasSameElements
-//import zio.test.TestAspect.{nondeterministic, sequential}
-//import zio.test.{Gen, ZIOSpecDefault, Spec, assert, assertTrue, checkN}
-//
-//object DynamoDbKeyValueStoreSpec extends ZIOSpecDefault {
-//
-//  private val dynamoDbKeyValueStore =
-//    dynamoDbLayer >+> DynamoDbKeyValueStore.layer
-//
-//  private val dynamoDbNameGen =
-//    Gen.alphaNumericStringBounded(
-//      min = 3,
-//      max = 255
-//    )
-//
-//  private val nonEmptyByteChunkGen =
-//    Gen.chunkOf1(Gen.byte)
-//
-//  private val byteChunkGen =
-//    Gen.chunkOf(Gen.byte)
-//
-//  override def spec: Spec[Environment, Any] =
-//    suite("DynamoDbKeyValueStoreSpec")(
-//      test("should be able to `put` (upsert) a key-value pair and then `get` it back.") {
-//        checkN(10)(
-//          dynamoDbNameGen,
-//          nonEmptyByteChunkGen,
-//          byteChunkGen,
-//          byteChunkGen
-//        ) { (namespace, key, value1, value2) =>
-//          ZIO.scoped {
-//            createDynamoDbTable(tableName) *> {
-//              for {
-//                putSucceeded1 <- KeyValueStore.put(namespace, key, value1)
-//                retrieved1    <- KeyValueStore.get(namespace, key)
-//                putSucceeded2 <- KeyValueStore.put(namespace, key, value2)
-//                retrieved2    <- KeyValueStore.get(namespace, key)
-//              } yield assertTrue(
-//                putSucceeded1,
-//                retrieved1.get == value1,
-//                putSucceeded2,
-//                retrieved2.get == value2
-//              )
-//            }
-//          }
-//        }
-//      },
-//      test("should return empty result for a `get` call when the namespace does not exist.") {
-//        checkN(10)(
-//          nonEmptyByteChunkGen
-//        ) { key =>
-//          val nonExistentNamespace = newTimeBasedName()
-//
-//          ZIO.scoped {
-//            createDynamoDbTable(tableName) *> {
-//              KeyValueStore
-//                .get(nonExistentNamespace, key)
-//                .map { retrieved =>
-//                  assertTrue(
-//                    retrieved.isEmpty
-//                  )
-//                }
-//            }
-//          }
-//        }
-//      },
-//      test("should return empty result for a `get` call when the key does not exist.") {
-//        checkN(10)(
-//          dynamoDbNameGen,
-//          nonEmptyByteChunkGen,
-//          byteChunkGen
-//        ) { (namespace, key, value) =>
-//          val nonExistingKey =
-//            Chunk.fromIterable(newTimeBasedName().getBytes)
-//
-//          ZIO.scoped {
-//            createDynamoDbTable(tableName) *> {
-//              for {
-//                putSucceeded <- KeyValueStore.put(namespace, key, value)
-//                retrieved    <- KeyValueStore.get(namespace, nonExistingKey)
-//              } yield assertTrue(
-//                retrieved.isEmpty,
-//                putSucceeded
-//              )
-//            }
-//          }
-//        }
-//      },
-//      test("should return empty result for a `scanAll` call when the namespace does not exist.") {
-//        val nonExistentNamespace = newTimeBasedName()
-//
-//        ZIO.scoped {
-//          createDynamoDbTable(tableName) *> {
-//            KeyValueStore
-//              .scanAll(nonExistentNamespace)
-//              .runCollect
-//              .map { retrieved =>
-//                assertTrue(retrieved.isEmpty)
-//              }
-//          }
-//        }
-//      },
-//      test("should return all key-value pairs for a `scanAll` call.") {
-//        val uniqueTableName = newTimeBasedName()
-//        val keyValuePairs =
-//          Chunk
-//            .fromIterable(1 to 1001)
-//            .map { n =>
-//              Chunk.fromArray(s"abc_$n".getBytes) -> Chunk.fromArray(s"xyz_$n".getBytes)
-//            }
-//        val expectedLength = keyValuePairs.length
-//
-//        ZIO.scoped {
-//          createDynamoDbTable(tableName) *> {
-//            for {
-//              putSuccesses <-
-//                ZIO
-//                  .foreach(keyValuePairs) { case (key, value) =>
-//                    KeyValueStore.put(uniqueTableName, key, value)
-//                  }
-//              retrieved <-
-//                KeyValueStore
-//                  .scanAll(uniqueTableName)
-//                  .runCollect
-//            } yield {
-//              assertTrue(
-//                putSuccesses.length == expectedLength,
-//                putSuccesses.toSet == Set(true),
-//                retrieved.length == expectedLength
-//              ) &&
-//              assert(retrieved)(
-//                hasSameElements(keyValuePairs)
-//              )
-//            }
-//          }
-//        }
-//      }
-//    ).provideCustomLayerShared(dynamoDbKeyValueStore) @@ nondeterministic @@ sequential
-//
-//  private def newTimeBasedName() =
-//    s"${java.time.Instant.now}"
-//      .replaceAll(":", "_")
-//      .replaceAll(".", "_")
-//}
+package zio.flow.dynamodb
+
+import DynamoDbKeyValueStore.tableName
+import DynamoDbSupport.{createDynamoDbTable, dynamoDbLayer}
+import zio.flow.internal.KeyValueStore
+import zio.{Chunk, ZIO}
+import zio.test.Assertion.hasSameElements
+import zio.test.TestAspect.{nondeterministic, sequential}
+import zio.test.{Gen, ZIOSpecDefault, Spec, assert, assertTrue, checkN}
+import zio.flow.internal.Timestamp
+
+object DynamoDbKeyValueStoreSpec extends ZIOSpecDefault {
+
+  private val dynamoDbKeyValueStore =
+    dynamoDbLayer >+> DynamoDbKeyValueStore.layer
+
+  private val dynamoDbNameGen =
+    Gen.alphaNumericStringBounded(
+      min = 3,
+      max = 255
+    )
+
+  private val nonEmptyByteChunkGen =
+    Gen.chunkOf1(Gen.byte)
+
+  private val byteChunkGen =
+    Gen.chunkOf(Gen.byte)
+
+  override def spec: Spec[Environment, Any] =
+    suite("DynamoDbKeyValueStoreSpec")(
+      test("should be able to `put` (upsert) a key-value pair and then `get` it back.") {
+        checkN(10)(
+          dynamoDbNameGen,
+          nonEmptyByteChunkGen,
+          byteChunkGen,
+          byteChunkGen
+        ) { (namespace, key, value1, value2) =>
+          ZIO.scoped {
+            createDynamoDbTable(tableName) *> {
+              for {
+                putSucceeded1 <- KeyValueStore.put(namespace, key, value1, Timestamp(1L))
+                retrieved1    <- KeyValueStore.getLatest(namespace, key, Some(Timestamp(1L)))
+                putSucceeded2 <- KeyValueStore.put(namespace, key, value2, Timestamp(2L))
+                retrieved2    <- KeyValueStore.getLatest(namespace, key, Some(Timestamp(2L)))
+              } yield assertTrue(
+                putSucceeded1,
+                retrieved1.get == value1,
+                putSucceeded2,
+                retrieved2.get == value2
+              )
+            }
+          }
+        }
+      },
+      test("should return empty result for a `get` call when the namespace does not exist.") {
+        checkN(10)(
+          nonEmptyByteChunkGen
+        ) { key =>
+          val nonExistentNamespace = newTimeBasedName()
+
+          ZIO.scoped {
+            createDynamoDbTable(tableName) *> {
+              KeyValueStore
+                .getLatest(nonExistentNamespace, key, None)
+                .map { retrieved =>
+                  assertTrue(
+                    retrieved.isEmpty
+                  )
+                }
+            }
+          }
+        }
+      },
+      test("should return empty result for a `get` call when the key does not exist.") {
+        checkN(10)(
+          dynamoDbNameGen,
+          nonEmptyByteChunkGen,
+          byteChunkGen
+        ) { (namespace, key, value) =>
+          val nonExistingKey =
+            Chunk.fromIterable(newTimeBasedName().getBytes)
+
+          ZIO.scoped {
+            createDynamoDbTable(tableName) *> {
+              for {
+                putSucceeded <- KeyValueStore.put(namespace, key, value, Timestamp(1L))
+                retrieved    <- KeyValueStore.getLatest(namespace, nonExistingKey, Some(Timestamp(1L)))
+              } yield assertTrue(
+                retrieved.isEmpty,
+                putSucceeded
+              )
+            }
+          }
+        }
+      },
+      test("should return empty result for a `scanAll` call when the namespace does not exist.") {
+        val nonExistentNamespace = newTimeBasedName()
+
+        ZIO.scoped {
+          createDynamoDbTable(tableName) *> {
+            KeyValueStore
+              .scanAll(nonExistentNamespace)
+              .runCollect
+              .map { retrieved =>
+                assertTrue(retrieved.isEmpty)
+              }
+          }
+        }
+      },
+      test("should return all key-value pairs for a `scanAll` call.") {
+        val uniqueTableName = newTimeBasedName()
+        val keyValuePairs =
+          Chunk
+            .fromIterable(1 to 1001)
+            .map { n =>
+              Chunk.fromArray(s"abc_$n".getBytes) -> Chunk.fromArray(s"xyz_$n".getBytes)
+            }
+        val expectedLength = keyValuePairs.length
+
+        ZIO.scoped {
+          createDynamoDbTable(tableName) *> {
+            for {
+              putSuccesses <-
+                ZIO
+                  .foreach(keyValuePairs) { case (key, value) =>
+                    KeyValueStore.put(uniqueTableName, key, value, Timestamp(1L))
+                  }
+              retrieved <-
+                KeyValueStore
+                  .scanAll(uniqueTableName)
+                  .runCollect
+            } yield {
+              assertTrue(
+                putSuccesses.length == expectedLength,
+                putSuccesses.toSet == Set(true),
+                retrieved.length == expectedLength
+              ) &&
+              assert(retrieved)(
+                hasSameElements(keyValuePairs)
+              )
+            }
+          }
+        }
+      }
+    ).provideCustomLayerShared(dynamoDbKeyValueStore) @@ nondeterministic @@ sequential
+
+  private def newTimeBasedName() =
+    s"${java.time.Instant.now}"
+      .replaceAll(":", "_")
+      .replaceAll(".", "_")
+}

--- a/dynamodb/src/it/scala/zio/flow/dynamodb/DynamoDbKeyValueStoreSpec.scala
+++ b/dynamodb/src/it/scala/zio/flow/dynamodb/DynamoDbKeyValueStoreSpec.scala
@@ -8,6 +8,7 @@ import zio.test.Assertion.hasSameElements
 import zio.test.TestAspect.{nondeterministic, sequential}
 import zio.test.{Gen, ZIOSpecDefault, Spec, assert, assertTrue, checkN}
 import zio.flow.internal.Timestamp
+import zio.test.Assertion.isNone
 
 object DynamoDbKeyValueStoreSpec extends ZIOSpecDefault {
 
@@ -39,8 +40,8 @@ object DynamoDbKeyValueStoreSpec extends ZIOSpecDefault {
             createDynamoDbTable(tableName) *> {
               for {
                 putSucceeded1 <- KeyValueStore.put(namespace, key, value1, Timestamp(1L))
-                retrieved1    <- KeyValueStore.getLatest(namespace, key, Some(Timestamp(1L)))
                 putSucceeded2 <- KeyValueStore.put(namespace, key, value2, Timestamp(2L))
+                retrieved1    <- KeyValueStore.getLatest(namespace, key, Some(Timestamp(1L)))
                 retrieved2    <- KeyValueStore.getLatest(namespace, key, Some(Timestamp(2L)))
               } yield assertTrue(
                 putSucceeded1,
@@ -48,6 +49,23 @@ object DynamoDbKeyValueStoreSpec extends ZIOSpecDefault {
                 putSucceeded2,
                 retrieved2.get == value2
               )
+            }
+          }
+        }
+      },
+      test("should be able to delete a key-value pair") {
+        checkN(10)(
+          dynamoDbNameGen,
+          nonEmptyByteChunkGen,
+          byteChunkGen
+        ) { (namespace, key, value1) =>
+          ZIO.scoped {
+            createDynamoDbTable(tableName) *> {
+              for {
+                _      <- KeyValueStore.put(namespace, key, value1, Timestamp(1L))
+                _      <- KeyValueStore.delete(namespace, key)
+                latest <- KeyValueStore.getLatest(namespace, key, Some(Timestamp(1)))
+              } yield assert(latest)(isNone)
             }
           }
         }

--- a/dynamodb/src/it/scala/zio/flow/dynamodb/DynamoDbSupport.scala
+++ b/dynamodb/src/it/scala/zio/flow/dynamodb/DynamoDbSupport.scala
@@ -1,6 +1,6 @@
 package zio.flow.dynamodb
 
-import DynamoDbKeyValueStore.{keyColumnName, namespaceColumnName}
+import DynamoDbKeyValueStore.{keyColumnName, timestampName}
 import LocalStackTestContainerSupport.awsContainer
 import com.dimafeng.testcontainers.LocalStackV2Container
 import zio.aws.core.config.AwsConfig
@@ -45,21 +45,21 @@ object DynamoDbSupport {
         tableName = name,
         attributeDefinitions = Seq(
           AttributeDefinition(
-            KeySchemaAttributeName(namespaceColumnName),
-            ScalarAttributeType.S
-          ),
-          AttributeDefinition(
             KeySchemaAttributeName(keyColumnName),
             ScalarAttributeType.B
+          ),
+          AttributeDefinition(
+            KeySchemaAttributeName(timestampName),
+            ScalarAttributeType.N
           )
         ),
         keySchema = List(
           KeySchemaElement(
-            KeySchemaAttributeName(namespaceColumnName),
+            KeySchemaAttributeName(keyColumnName),
             KeyType.HASH
           ),
           KeySchemaElement(
-            KeySchemaAttributeName(keyColumnName),
+            KeySchemaAttributeName(timestampName),
             KeyType.RANGE
           )
         ),

--- a/dynamodb/src/it/scala/zio/flow/dynamodb/DynamoDbSupport.scala
+++ b/dynamodb/src/it/scala/zio/flow/dynamodb/DynamoDbSupport.scala
@@ -1,102 +1,102 @@
-//package zio.flow.dynamodb
-//
-//import DynamoDbKeyValueStore.{keyColumnName, namespaceColumnName}
-//import LocalStackTestContainerSupport.awsContainer
-//import com.dimafeng.testcontainers.LocalStackV2Container
-//import zio.aws.core.config.AwsConfig
-//import zio.aws.dynamodb.DynamoDb
-//import zio.aws.dynamodb.model._
-//import org.testcontainers.containers.localstack.LocalStackContainer.{Service => AwsService}
-//import zio.aws.dynamodb.model.primitives.{KeySchemaAttributeName, PositiveLongObject, TableName}
-//import zio.aws.netty.NettyHttpClient
-//import zio.{&, RLayer, Scope, ULayer, ZIO, ZLayer}
-//
-///**
-// * A helper module for LocalStack DynamoDB integration. It contains helper
-// * methods to create/delete a DynamoDB table, construct ZLayers, etc.
-// */
-//object DynamoDbSupport {
-//
-//  type DynamoDB = ULayer[DynamoDb]
-//
-//  lazy val dynamoDb: RLayer[AwsConfig & LocalStackV2Container, DynamoDb] =
-//    ZLayer.scoped {
-//      for {
-//        awsContainer <- ZIO.service[LocalStackV2Container]
-//        dynamoDbService <-
-//          DynamoDb.scoped(
-//            _.credentialsProvider(
-//              awsContainer.staticCredentialsProvider
-//            )
-//              .region(awsContainer.region)
-//              .endpointOverride(
-//                awsContainer.endpointOverride(AwsService.DYNAMODB)
-//              )
-//          )
-//      } yield dynamoDbService
-//    }
-//
-//  lazy val dynamoDbLayer: DynamoDB =
-//    awsLayerFor(Seq(AwsService.DYNAMODB))
-//
-//  def createDynamoDbTable(name: TableName): ZIO[DynamoDb with Scope, Throwable, TableDescription.ReadOnly] = {
-//    val createTableRequest =
-//      CreateTableRequest(
-//        tableName = name,
-//        attributeDefinitions = Seq(
-//          AttributeDefinition(
-//            KeySchemaAttributeName(namespaceColumnName),
-//            ScalarAttributeType.S
-//          ),
-//          AttributeDefinition(
-//            KeySchemaAttributeName(keyColumnName),
-//            ScalarAttributeType.B
-//          )
-//        ),
-//        keySchema = List(
-//          KeySchemaElement(
-//            KeySchemaAttributeName(namespaceColumnName),
-//            KeyType.HASH
-//          ),
-//          KeySchemaElement(
-//            KeySchemaAttributeName(keyColumnName),
-//            KeyType.RANGE
-//          )
-//        ),
-//        provisionedThroughput = Option(
-//          ProvisionedThroughput(
-//            readCapacityUnits = PositiveLongObject(16L),
-//            writeCapacityUnits = PositiveLongObject(16L)
-//          )
-//        )
-//      )
-//
-//    ZIO
-//      .acquireRelease(
-//        for {
-//          tableData <- DynamoDb.createTable(createTableRequest)
-//          tableDesc <- tableData.getTableDescription
-//        } yield tableDesc
-//      )(
-//        _.getTableName.flatMap { tableName =>
-//          DynamoDb
-//            .deleteTable(
-//              DeleteTableRequest(tableName)
-//            )
-//            .unit
-//        }
-//          .catchAll(error => ZIO.die(error.toThrowable))
-//          .unit
-//      )
-//      .mapError(_.toThrowable)
-//  }
-//
-//  private def awsLayerFor(
-//    awsServices: Seq[LocalStackV2Container.Service]
-//  ): DynamoDB = (
-//    (
-//      (NettyHttpClient.default >>> AwsConfig.default) ++
-//        awsContainer(awsServices = awsServices)
-//    ) >>> dynamoDb
-//  ).orDie
-//}
+package zio.flow.dynamodb
+
+import DynamoDbKeyValueStore.{keyColumnName, namespaceColumnName}
+import LocalStackTestContainerSupport.awsContainer
+import com.dimafeng.testcontainers.LocalStackV2Container
+import zio.aws.core.config.AwsConfig
+import zio.aws.dynamodb.DynamoDb
+import zio.aws.dynamodb.model._
+import org.testcontainers.containers.localstack.LocalStackContainer.{Service => AwsService}
+import zio.aws.dynamodb.model.primitives.{KeySchemaAttributeName, PositiveLongObject, TableName}
+import zio.aws.netty.NettyHttpClient
+import zio.{&, RLayer, Scope, ULayer, ZIO, ZLayer}
+
+/**
+ * A helper module for LocalStack DynamoDB integration. It contains helper
+ * methods to create/delete a DynamoDB table, construct ZLayers, etc.
+ */
+object DynamoDbSupport {
+
+  type DynamoDB = ULayer[DynamoDb]
+
+  lazy val dynamoDb: RLayer[AwsConfig & LocalStackV2Container, DynamoDb] =
+    ZLayer.scoped {
+      for {
+        awsContainer <- ZIO.service[LocalStackV2Container]
+        dynamoDbService <-
+          DynamoDb.scoped(
+            _.credentialsProvider(
+              awsContainer.staticCredentialsProvider
+            )
+              .region(awsContainer.region)
+              .endpointOverride(
+                awsContainer.endpointOverride(AwsService.DYNAMODB)
+              )
+          )
+      } yield dynamoDbService
+    }
+
+  lazy val dynamoDbLayer: DynamoDB =
+    awsLayerFor(Seq(AwsService.DYNAMODB))
+
+  def createDynamoDbTable(name: TableName): ZIO[DynamoDb with Scope, Throwable, TableDescription.ReadOnly] = {
+    val createTableRequest =
+      CreateTableRequest(
+        tableName = name,
+        attributeDefinitions = Seq(
+          AttributeDefinition(
+            KeySchemaAttributeName(namespaceColumnName),
+            ScalarAttributeType.S
+          ),
+          AttributeDefinition(
+            KeySchemaAttributeName(keyColumnName),
+            ScalarAttributeType.B
+          )
+        ),
+        keySchema = List(
+          KeySchemaElement(
+            KeySchemaAttributeName(namespaceColumnName),
+            KeyType.HASH
+          ),
+          KeySchemaElement(
+            KeySchemaAttributeName(keyColumnName),
+            KeyType.RANGE
+          )
+        ),
+        provisionedThroughput = Option(
+          ProvisionedThroughput(
+            readCapacityUnits = PositiveLongObject(16L),
+            writeCapacityUnits = PositiveLongObject(16L)
+          )
+        )
+      )
+
+    ZIO
+      .acquireRelease(
+        for {
+          tableData <- DynamoDb.createTable(createTableRequest)
+          tableDesc <- tableData.getTableDescription
+        } yield tableDesc
+      )(
+        _.getTableName.flatMap { tableName =>
+          DynamoDb
+            .deleteTable(
+              DeleteTableRequest(tableName)
+            )
+            .unit
+        }
+          .catchAll(error => ZIO.die(error.toThrowable))
+          .unit
+      )
+      .mapError(_.toThrowable)
+  }
+
+  private def awsLayerFor(
+    awsServices: Seq[LocalStackV2Container.Service]
+  ): DynamoDB = (
+    (
+      (NettyHttpClient.default >>> AwsConfig.default) ++
+        awsContainer(awsServices = awsServices)
+    ) >>> dynamoDb
+  ).orDie
+}

--- a/dynamodb/src/main/scala/zio/flow/dynamodb/DynamoDbKeyValueStore.scala
+++ b/dynamodb/src/main/scala/zio/flow/dynamodb/DynamoDbKeyValueStore.scala
@@ -17,6 +17,7 @@ import zio.aws.dynamodb.model.BatchWriteItemRequest
 import zio.aws.dynamodb.model.WriteRequest
 import zio.prelude.data.Optional
 import zio.aws.dynamodb.model.DeleteRequest
+import scala.util.Try
 
 final class DynamoDbKeyValueStore(dynamoDB: DynamoDb) extends KeyValueStore {
 
@@ -89,7 +90,7 @@ final class DynamoDbKeyValueStore(dynamoDB: DynamoDb) extends KeyValueStore {
             rawTimestamp <- result.get(AttributeName(timestampName))
             byteChunk    <- rawBytes.b.toOption
             timestampStr <- rawTimestamp.n.toOption
-            timestamp    <- timestampStr.toLongOption
+            timestamp    <- Try(timestampStr.toLong).toOption
           } yield (byteChunk, Timestamp(timestamp))
       )
       .flatMap(bytesOption => ZStream.fromIterable(bytesOption))
@@ -160,7 +161,7 @@ final class DynamoDbKeyValueStore(dynamoDB: DynamoDb) extends KeyValueStore {
           for {
             rawTimestamp <- result.get(AttributeName(timestampName))
             timestampStr <- rawTimestamp.n.toOption
-            timestamp    <- timestampStr.toLongOption
+            timestamp    <- Try(timestampStr.toLong).toOption
           } yield Timestamp(timestamp)
       )
       .flatMap(bytesOption => ZStream.fromIterable(bytesOption))

--- a/dynamodb/src/main/scala/zio/flow/dynamodb/DynamoDbKeyValueStore.scala
+++ b/dynamodb/src/main/scala/zio/flow/dynamodb/DynamoDbKeyValueStore.scala
@@ -1,206 +1,194 @@
-//package zio.flow.dynamodb
-//
-//import zio.aws.core.AwsError
-//import zio.aws.dynamodb.DynamoDb
-//import zio.aws.dynamodb.model.primitives._
-//import zio.aws.dynamodb.model.{
-//  AttributeValue,
-//  DeleteItemRequest,
-//  GetItemRequest,
-//  Put,
-//  ScanRequest,
-//  TransactWriteItem,
-//  TransactWriteItemsRequest,
-//  UpdateItemRequest
-//}
-//import DynamoDbKeyValueStore._
-//import zio.flow.internal.KeyValueStore
-//import zio.stream.ZStream
-//import zio.{Chunk, IO, URLayer, ZIO, ZLayer}
-//
-//import java.io.IOException
-//
-//final class DynamoDbKeyValueStore(dynamoDB: DynamoDb) extends KeyValueStore {
-//
-//  override def put(
-//    namespace: String,
-//    key: Chunk[Byte],
-//    value: Chunk[Byte]
-//  ): IO[IOException, Boolean] = {
-//
-//    val request =
-//      UpdateItemRequest(
-//        tableName,
-//        dynamoDbKey(namespace, key),
-//        updateExpression = Option(
-//          UpdateExpression(
-//            s"SET $valueColumnName = ${RequestExpressionPlaceholder.valueColumn}"
-//          )
-//        ),
-//        expressionAttributeValues = Option(
-//          Map(
-//            ExpressionAttributeValueVariable(RequestExpressionPlaceholder.valueColumn) -> binaryValue(value)
-//          )
-//        )
-//      )
-//
-//    dynamoDB
-//      .updateItem(request)
-//      .mapBoth(
-//        ioExceptionOf(s"Error putting key-value pair for <$namespace> namespace", _),
-//        _ => true
-//      )
-//  }
-//
-//  override def get(namespace: String, key: Chunk[Byte]): IO[IOException, Option[Chunk[Byte]]] = {
-//
-//    val request =
-//      GetItemRequest(
-//        tableName,
-//        dynamoDbKey(namespace, key),
-//        projectionExpression = Option(
-//          ProjectionExpression(valueColumnName)
-//        )
-//      )
-//
-//    dynamoDB
-//      .getItem(request)
-//      .mapBoth(
-//        ioExceptionOf(s"Error retrieving or reading value for <$namespace> namespace", _),
-//        result =>
-//          for {
-//            item      <- result.item.toOption
-//            value     <- item.get(AttributeName(valueColumnName))
-//            byteChunk <- value.b.toOption
-//          } yield byteChunk
-//      )
-//  }
-//
-//  override def scanAll(namespace: String): ZStream[Any, IOException, (Chunk[Byte], Chunk[Byte])] = {
-//
-//    val request = scanRequest.copy(
-//      expressionAttributeValues = Option(
-//        Map(
-//          ExpressionAttributeValueVariable(RequestExpressionPlaceholder.namespaceColumn) -> stringValue(namespace)
-//        )
-//      )
-//    )
-//
-//    dynamoDB
-//      .scan(request)
-//      .mapBoth(
-//        ioExceptionOf(s"Error scanning all key-value pairs for <$namespace> namespace", _),
-//        item =>
-//          for {
-//            key            <- item.get(AttributeName(keyColumnName))
-//            keyByteChunk   <- key.b.toOption
-//            value          <- item.get(AttributeName(valueColumnName))
-//            valueByteChunk <- value.b.toOption
-//          } yield {
-//            keyByteChunk -> valueByteChunk
-//          }
-//      )
-//      .collect { case Some(byteChunkPair) =>
-//        byteChunkPair
-//      }
-//  }
-//
-//  override def delete(namespace: String, key: Chunk[Byte]): IO[IOException, Unit] =
-//    dynamoDB
-//      .deleteItem(
-//        DeleteItemRequest(
-//          tableName = tableName,
-//          key = dynamoDbKey(namespace, key)
-//        )
-//      )
-//      .mapBoth(
-//        ioExceptionOf(s"Error deleting item from <$namespace> namespace", _),
-//        _ => ()
-//      )
-//
-//  override def putAll(items: Chunk[KeyValueStore.Item]): IO[IOException, Unit] =
-//    dynamoDB
-//      .transactWriteItems(
-//        TransactWriteItemsRequest(
-//          transactItems = items.map { item =>
-//            TransactWriteItem(
-//              put = Put(
-//                tableName = tableName,
-//                item = dynamoDbKey(item.namespace, item.key) +
-//                  (AttributeName(valueColumnName) -> binaryValue(item.value))
-//              )
-//            )
-//          }
-//        )
-//      )
-//      .mapBoth(
-//        ioExceptionOf(s"Error putting multiple items transactionally", _),
-//        _ => ()
-//      )
-//}
-//
-//object DynamoDbKeyValueStore {
-//  val layer: URLayer[DynamoDb, KeyValueStore] =
-//    ZLayer {
-//      ZIO
-//        .service[DynamoDb]
-//        .map(new DynamoDbKeyValueStore(_))
-//    }
-//
-//  private[dynamodb] val tableName: TableName = TableName("_zflow_key_value_store")
-//// TODO
-//
-//  private[dynamodb] val namespaceColumnName: String =
-//    withColumnPrefix("namespace")
-//
-//  private[dynamodb] val keyColumnName: String =
-//    withColumnPrefix("key")
-//
-//  private[dynamodb] val valueColumnName: String =
-//    withColumnPrefix("value")
-//
-//  private object RequestExpressionPlaceholder {
-//    val namespaceColumn: String = ":namespaceValue"
-//    val valueColumn: String     = ":valueColumnValue"
-//  }
-//
-//  private val scanRequest: ScanRequest =
-//    ScanRequest(
-//      tableName,
-//      projectionExpression = Option(
-//        ProjectionExpression(
-//          Seq(keyColumnName, valueColumnName).mkString(", ")
-//        )
-//      ),
-//      filterExpression = Option(
-//        ConditionExpression(
-//          s"$namespaceColumnName = ${RequestExpressionPlaceholder.namespaceColumn}"
-//        )
-//      )
-//    )
-//
-//  private def binaryValue(b: Chunk[Byte]): AttributeValue =
-//    AttributeValue(
-//      b = Option(BinaryAttributeValue(b))
-//    )
-//
-//  private def stringValue(s: String): AttributeValue =
-//    AttributeValue(
-//      s = Option(StringAttributeValue(s))
-//    )
-//
-//  private def dynamoDbKey(namespace: String, key: Chunk[Byte]): Map[AttributeName, AttributeValue] =
-//    Map(
-//      AttributeName(namespaceColumnName) -> stringValue(namespace),
-//      AttributeName(keyColumnName)       -> binaryValue(key)
-//    )
-//
-//  private def ioExceptionOf(errorContext: String, awsError: AwsError): IOException = {
-//    val error = awsError.toThrowable
-//
-//    new IOException(s"$errorContext: <${error.getMessage}>.", error)
-//  }
-//
-//  private def withColumnPrefix(s: String) =
-//    "zflow_kv_" + s
-//}
+package zio.flow.dynamodb
+
+import zio.aws.core.AwsError
+import zio.aws.dynamodb.DynamoDb
+import zio.aws.dynamodb.model.primitives._
+import zio.aws.dynamodb.model.{
+  AttributeValue,
+  DeleteItemRequest,
+  GetItemRequest,
+  Put,
+  ScanRequest,
+  TransactWriteItem,
+  TransactWriteItemsRequest,
+  UpdateItemRequest
+}
+import DynamoDbKeyValueStore._
+import zio.flow.internal.KeyValueStore
+import zio.stream.ZStream
+import zio.{Chunk, IO, URLayer, ZIO, ZLayer}
+
+import java.io.IOException
+import zio.flow.internal.Timestamp
+
+final class DynamoDbKeyValueStore(dynamoDB: DynamoDb) extends KeyValueStore {
+
+  override def put(
+    namespace: String,
+    key: Chunk[Byte],
+    value: Chunk[Byte],
+    timestamp: Timestamp
+  ): IO[IOException, Boolean] = {
+
+    val request =
+      UpdateItemRequest(
+        tableName,
+        dynamoDbKey(namespace, key),
+        updateExpression = Option(
+          UpdateExpression(
+            s"SET $valueColumnName = ${RequestExpressionPlaceholder.valueColumn}"
+          )
+        ),
+        expressionAttributeValues = Option(
+          Map(
+            ExpressionAttributeValueVariable(RequestExpressionPlaceholder.valueColumn) -> binaryValue(value)
+          )
+        )
+      )
+
+    dynamoDB
+      .updateItem(request)
+      .mapBoth(
+        ioExceptionOf(s"Error putting key-value pair for <$namespace> namespace", _),
+        _ => true
+      )
+  }
+
+  override def getLatest(
+    namespace: String,
+    key: Chunk[Byte],
+    before: Option[Timestamp]
+  ): IO[IOException, Option[Chunk[Byte]]] = {
+
+    val request =
+      GetItemRequest(
+        tableName,
+        dynamoDbKey(namespace, key),
+        projectionExpression = Option(
+          ProjectionExpression(valueColumnName)
+        )
+      )
+
+    dynamoDB
+      .getItem(request)
+      .mapBoth(
+        ioExceptionOf(s"Error retrieving or reading value for <$namespace> namespace", _),
+        result =>
+          for {
+            item      <- result.item.toOption
+            value     <- item.get(AttributeName(valueColumnName))
+            byteChunk <- value.b.toOption
+          } yield byteChunk
+      )
+  }
+
+  override def getLatestTimestamp(namespace: String, key: Chunk[Byte]): IO[IOException, Option[Timestamp]] = ???
+
+  override def scanAll(namespace: String): ZStream[Any, IOException, (Chunk[Byte], Chunk[Byte])] = {
+
+    val request = scanRequest.copy(
+      expressionAttributeValues = Option(
+        Map(
+          ExpressionAttributeValueVariable(RequestExpressionPlaceholder.namespaceColumn) -> stringValue(namespace)
+        )
+      )
+    )
+
+    dynamoDB
+      .scan(request)
+      .mapBoth(
+        ioExceptionOf(s"Error scanning all key-value pairs for <$namespace> namespace", _),
+        item =>
+          for {
+            key            <- item.get(AttributeName(keyColumnName))
+            keyByteChunk   <- key.b.toOption
+            value          <- item.get(AttributeName(valueColumnName))
+            valueByteChunk <- value.b.toOption
+          } yield {
+            keyByteChunk -> valueByteChunk
+          }
+      )
+      .collect { case Some(byteChunkPair) =>
+        byteChunkPair
+      }
+  }
+
+  override def delete(namespace: String, key: Chunk[Byte]): IO[IOException, Unit] =
+    dynamoDB
+      .deleteItem(
+        DeleteItemRequest(
+          tableName = tableName,
+          key = dynamoDbKey(namespace, key)
+        )
+      )
+      .mapBoth(
+        ioExceptionOf(s"Error deleting item from <$namespace> namespace", _),
+        _ => ()
+      )
+}
+
+object DynamoDbKeyValueStore {
+  val layer: URLayer[DynamoDb, KeyValueStore] =
+    ZLayer {
+      ZIO
+        .service[DynamoDb]
+        .map(new DynamoDbKeyValueStore(_))
+    }
+
+  private[dynamodb] val tableName: TableName = TableName("_zflow_key_value_store")
+// TODO
+
+  private[dynamodb] val namespaceColumnName: String =
+    withColumnPrefix("namespace")
+
+  private[dynamodb] val keyColumnName: String =
+    withColumnPrefix("key")
+
+  private[dynamodb] val valueColumnName: String =
+    withColumnPrefix("value")
+
+  private object RequestExpressionPlaceholder {
+    val namespaceColumn: String = ":namespaceValue"
+    val valueColumn: String     = ":valueColumnValue"
+  }
+
+  private val scanRequest: ScanRequest =
+    ScanRequest(
+      tableName,
+      projectionExpression = Option(
+        ProjectionExpression(
+          Seq(keyColumnName, valueColumnName).mkString(", ")
+        )
+      ),
+      filterExpression = Option(
+        ConditionExpression(
+          s"$namespaceColumnName = ${RequestExpressionPlaceholder.namespaceColumn}"
+        )
+      )
+    )
+
+  private def binaryValue(b: Chunk[Byte]): AttributeValue =
+    AttributeValue(
+      b = Option(BinaryAttributeValue(b))
+    )
+
+  private def stringValue(s: String): AttributeValue =
+    AttributeValue(
+      s = Option(StringAttributeValue(s))
+    )
+
+  private def dynamoDbKey(namespace: String, key: Chunk[Byte]): Map[AttributeName, AttributeValue] =
+    Map(
+      AttributeName(namespaceColumnName) -> stringValue(namespace),
+      AttributeName(keyColumnName)       -> binaryValue(key)
+    )
+
+  private def ioExceptionOf(errorContext: String, awsError: AwsError): IOException = {
+    val error = awsError.toThrowable
+
+    new IOException(s"$errorContext: <${error.getMessage}>.", error)
+  }
+
+  private def withColumnPrefix(s: String) =
+    "zflow_kv_" + s
+}

--- a/zio-flow/shared/src/main/scala/zio/flow/internal/KeyValueStore.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/internal/KeyValueStore.scala
@@ -66,6 +66,11 @@ object KeyValueStore {
       _.scanAll(namespace)
     )
 
+  def delete(namespace: String, key: Chunk[Byte]): ZIO[KeyValueStore, IOException, Unit] =
+    ZIO.serviceWithZIO(
+      _.delete(namespace, key)
+    )
+
   private final case class InMemoryKeyValueEntry(data: Chunk[Byte], timestamp: Timestamp) {
     override def toString: String = s"<entry ($data.size bytes) at $timestamp>"
   }


### PR DESCRIPTION
Uncomment DynamoDbKeyValueStore and related tests and update to the latest KeyValueStore trait, supporting timestamps.

DynamoDB primary keys can only have two attributes (Partition Key and Sort Key), and performant queries can only be executed if conditions use these two attributes, everything else would require a complete table scan. Additionally, there is support for secondary indexes which can also have one partition key and one sort key. Having to search based on timestamps adds some complexity, as now we have three attributes in our filter conditions: namespace, key, and timestamp.

I considered two options to circumvent this issue, I would appreciate some help to decide which one fits better.

1. Have a separate DynamoDB table per namespace. All KV store operations use a namespace, so we would be able to determine the table as well. However, I am not sure if the namespaces in the future would not be dynamic, and I think having to maintain multiple DynamoDB tables adds more burden to the user side, so I went with the second option.
2. Have one table, but represent the key attribute as a concatenation of the utf8-encoded namespace and the key bytes. This way we can effectively query based on namespace+key+timestamp. When reading back keys, the namespace should be stripped from the beginning. This also adds some complexity be requiring a secondary index to be defined on the table on the `namespace` attribute to be able to execute `scanAll`.

Let me know what you think :)