### PR TITLE
Support timestamps in CassandraKeyValueStore

### DIFF
--- a/cassandra/src/it/scala/zio/flow/cassandra/CassandraKeyValueStoreSpec.scala
+++ b/cassandra/src/it/scala/zio/flow/cassandra/CassandraKeyValueStoreSpec.scala
@@ -1,136 +1,135 @@
-// TODO
-//package zio.flow.cassandra
-//
-//import CassandraTestContainerSupport.{SessionLayer, cassandraV3, cassandraV4, scyllaDb}
-//import zio.flow.internal.KeyValueStore
-//import zio.{Chunk, ZIO}
-//import zio.test.Assertion.hasSameElements
-//import zio.test.TestAspect.{nondeterministic, sequential}
-//import zio.test.{Gen, Spec, assert, assertTrue, checkN, ZIOSpecDefault}
-//
-//object CassandraKeyValueStoreSpec extends ZIOSpecDefault {
-//
-//  private val cqlNameGen =
-//    Gen.alphaNumericStringBounded(
-//      min = 1,
-//      max = 48
-//    )
-//
-//  private val nonEmptyByteChunkGen =
-//    Gen.chunkOf1(Gen.byte)
-//
-//  private val byteChunkGen =
-//    Gen.chunkOf(Gen.byte)
-//
-//  override def spec: Spec[Environment, Any] =
-//    suite("CassandraKeyValueStoreSpec")(
-//      testUsing(cassandraV3, "Cassandra V3"),
-//      testUsing(cassandraV4, "Cassandra V4"),
-//      testUsing(scyllaDb, "ScyllaDB")
-//    )
-//
-//  private def testUsing(database: SessionLayer, label: String) =
-//    suite(label)(
-//      test("should be able to `put` (upsert) a key-value pair and then `get` it back.") {
-//        checkN(10)(
-//          cqlNameGen,
-//          nonEmptyByteChunkGen,
-//          byteChunkGen,
-//          byteChunkGen
-//        ) { (namespace, key, value1, value2) =>
-//          for {
-//            putSucceeded1 <- KeyValueStore.put(namespace, key, value1)
-//            retrieved1    <- KeyValueStore.get(namespace, key)
-//            putSucceeded2 <- KeyValueStore.put(namespace, key, value2)
-//            retrieved2    <- KeyValueStore.get(namespace, key)
-//          } yield assertTrue(
-//            putSucceeded1,
-//            retrieved1.get == value1,
-//            putSucceeded2,
-//            retrieved2.get == value2
-//          )
-//        }
-//      },
-//      test("should return empty result for a `get` call when the namespace does not exist.") {
-//        checkN(10)(
-//          nonEmptyByteChunkGen
-//        ) { key =>
-//          val nonExistentNamespace = newTimeBasedName()
-//
-//          KeyValueStore
-//            .get(nonExistentNamespace, key)
-//            .map { retrieved =>
-//              assertTrue(
-//                retrieved.isEmpty
-//              )
-//            }
-//        }
-//      },
-//      test("should return empty result for a `get` call when the key does not exist.") {
-//        checkN(10)(
-//          cqlNameGen,
-//          nonEmptyByteChunkGen,
-//          byteChunkGen
-//        ) { (namespace, key, value) =>
-//          val nonExistingKey =
-//            Chunk.fromIterable(newTimeBasedName().getBytes)
-//
-//          for {
-//            putSucceeded <- KeyValueStore.put(namespace, key, value)
-//            retrieved    <- KeyValueStore.get(namespace, nonExistingKey)
-//          } yield assertTrue(
-//            retrieved.isEmpty,
-//            putSucceeded
-//          )
-//        }
-//      },
-//      test("should return empty result for a `scanAll` call when the namespace does not exist.") {
-//        val nonExistentNamespace = newTimeBasedName()
-//
-//        KeyValueStore
-//          .scanAll(nonExistentNamespace)
-//          .runCollect
-//          .map { retrieved =>
-//            assertTrue(
-//              retrieved.isEmpty
-//            )
-//          }
-//      },
-//      test("should return all key-value pairs for a `scanAll` call.") {
-//        val uniqueNamespace = newTimeBasedName()
-//        val keyValuePairs =
-//          Chunk
-//            .fromIterable(1 to 5001)
-//            .map { n =>
-//              Chunk.fromArray(s"abc_$n".getBytes) -> Chunk.fromArray(s"xyz_$n".getBytes)
-//            }
-//        val expectedLength = keyValuePairs.length
-//
-//        for {
-//          putSuccesses <-
-//            ZIO
-//              .foreachPar(keyValuePairs) { case (key, value) =>
-//                KeyValueStore.put(uniqueNamespace, key, value)
-//              }
-//          retrieved <-
-//            KeyValueStore
-//              .scanAll(uniqueNamespace)
-//              .runCollect
-//        } yield {
-//          assertTrue(
-//            putSuccesses.length == expectedLength,
-//            putSuccesses.toSet == Set(true),
-//            retrieved.length == expectedLength
-//          ) &&
-//          assert(retrieved)(
-//            hasSameElements(keyValuePairs)
-//          )
-//        }
-//      }
-//    ).provideCustomLayerShared(database >>> CassandraKeyValueStore.layer) @@ nondeterministic @@ sequential
-//
-//  private def newTimeBasedName() =
-//    s"${java.time.Instant.now}"
-//      .replaceAll(":", "_")
-//      .replaceAll(".", "_")
-//}
+package zio.flow.cassandra
+
+import CassandraTestContainerSupport.{SessionLayer, cassandraV3, cassandraV4, scyllaDb}
+import zio.flow.internal.KeyValueStore
+import zio.{Chunk, ZIO}
+import zio.test.Assertion.hasSameElements
+import zio.test.TestAspect.{nondeterministic, sequential}
+import zio.test.{Gen, Spec, assert, assertTrue, checkN, ZIOSpecDefault}
+
+object CassandraKeyValueStoreSpec extends ZIOSpecDefault {
+
+  private val cqlNameGen =
+    Gen.alphaNumericStringBounded(
+      min = 1,
+      max = 48
+    )
+
+  private val nonEmptyByteChunkGen =
+    Gen.chunkOf1(Gen.byte)
+
+  private val byteChunkGen =
+    Gen.chunkOf(Gen.byte)
+
+  override def spec: Spec[Environment, Any] =
+    suite("CassandraKeyValueStoreSpec")(
+      testUsing(cassandraV3, "Cassandra V3"),
+      testUsing(cassandraV4, "Cassandra V4"),
+      testUsing(scyllaDb, "ScyllaDB")
+    )
+
+  private def testUsing(database: SessionLayer, label: String) =
+    suite(label)(
+      test("should be able to `put` (upsert) a key-value pair and then `get` it back.") {
+        checkN(10)(
+          cqlNameGen,
+          nonEmptyByteChunkGen,
+          byteChunkGen,
+          byteChunkGen
+        ) { (namespace, key, value1, value2) =>
+          for {
+            putSucceeded1 <- KeyValueStore.put(namespace, key, value1)
+            retrieved1    <- KeyValueStore.get(namespace, key)
+            putSucceeded2 <- KeyValueStore.put(namespace, key, value2)
+            retrieved2    <- KeyValueStore.get(namespace, key)
+          } yield assertTrue(
+            putSucceeded1,
+            retrieved1.get == value1,
+            putSucceeded2,
+            retrieved2.get == value2
+          )
+        }
+      },
+      test("should return empty result for a `get` call when the namespace does not exist.") {
+        checkN(10)(
+          nonEmptyByteChunkGen
+        ) { key =>
+          val nonExistentNamespace = newTimeBasedName()
+
+          KeyValueStore
+            .get(nonExistentNamespace, key)
+            .map { retrieved =>
+              assertTrue(
+                retrieved.isEmpty
+              )
+            }
+        }
+      },
+      test("should return empty result for a `get` call when the key does not exist.") {
+        checkN(10)(
+          cqlNameGen,
+          nonEmptyByteChunkGen,
+          byteChunkGen
+        ) { (namespace, key, value) =>
+          val nonExistingKey =
+            Chunk.fromIterable(newTimeBasedName().getBytes)
+
+          for {
+            putSucceeded <- KeyValueStore.put(namespace, key, value)
+            retrieved    <- KeyValueStore.get(namespace, nonExistingKey)
+          } yield assertTrue(
+            retrieved.isEmpty,
+            putSucceeded
+          )
+        }
+      },
+      test("should return empty result for a `scanAll` call when the namespace does not exist.") {
+        val nonExistentNamespace = newTimeBasedName()
+
+        KeyValueStore
+          .scanAll(nonExistentNamespace)
+          .runCollect
+          .map { retrieved =>
+            assertTrue(
+              retrieved.isEmpty
+            )
+          }
+      },
+      test("should return all key-value pairs for a `scanAll` call.") {
+        val uniqueNamespace = newTimeBasedName()
+        val keyValuePairs =
+          Chunk
+            .fromIterable(1 to 5001)
+            .map { n =>
+              Chunk.fromArray(s"abc_$n".getBytes) -> Chunk.fromArray(s"xyz_$n".getBytes)
+            }
+        val expectedLength = keyValuePairs.length
+
+        for {
+          putSuccesses <-
+            ZIO
+              .foreachPar(keyValuePairs) { case (key, value) =>
+                KeyValueStore.put(uniqueNamespace, key, value)
+              }
+          retrieved <-
+            KeyValueStore
+              .scanAll(uniqueNamespace)
+              .runCollect
+        } yield {
+          assertTrue(
+            putSuccesses.length == expectedLength,
+            putSuccesses.toSet == Set(true),
+            retrieved.length == expectedLength
+          ) &&
+          assert(retrieved)(
+            hasSameElements(keyValuePairs)
+          )
+        }
+      }
+    ).provideCustomLayerShared(database >>> CassandraKeyValueStore.layer) @@ nondeterministic @@ sequential
+
+  private def newTimeBasedName() =
+    s"${java.time.Instant.now}"
+      .replaceAll(":", "_")
+      .replaceAll(".", "_")
+}

--- a/cassandra/src/it/scala/zio/flow/cassandra/CassandraTestContainerSupport.scala
+++ b/cassandra/src/it/scala/zio/flow/cassandra/CassandraTestContainerSupport.scala
@@ -1,158 +1,142 @@
-//package zio.flow.cassandra
-//
-//import com.datastax.oss.driver.api.core.`type`.DataTypes
-//import com.datastax.oss.driver.api.core.{CqlIdentifier, CqlSession}
-//import com.datastax.oss.driver.api.querybuilder.SchemaBuilder
-//import com.dimafeng.testcontainers.CassandraContainer
-//
-//import java.net.InetSocketAddress
-//import org.testcontainers.utility.DockerImageName
-//import zio.{ULayer, URLayer, ZIO, ZLayer}
-//import zio.ZIO.{attemptBlocking, fromCompletionStage => execAsync}
-//
-///**
-// * A helper module for test-containers integration. Mostly this facilitates
-// * spinning up Cassandra/Scylla containers, then obtaining the container's IP &
-// * port, and finally creating the keyspace and the table for testing.
-// */
-//object CassandraTestContainerSupport {
-//
-//  type SessionLayer = ULayer[CqlSession]
-//
-//  private val cassandra        = "cassandra"
-//  private val testKeyspaceName = "CassandraKeyValueStoreSpec_Keyspace"
-//  private val testDataCenter   = "datacenter1"
-//
-//  private val createTable =
-//    SchemaBuilder
-//      .createTable(testKeyspaceName, CassandraKeyValueStore.tableName)
-//      .withPartitionKey(
-//        CassandraKeyValueStore.namespaceColumnName,
-//        DataTypes.TEXT
-//      )
-//      .withClusteringColumn(
-//        CassandraKeyValueStore.keyColumnName,
-//        DataTypes.BLOB
-//      )
-//      .withColumn(
-//        CassandraKeyValueStore.valueColumnName,
-//        DataTypes.BLOB
-//      )
-//      .build
-//
-//  private val createVersionTable =
-//    SchemaBuilder
-//      .createTable(testKeyspaceName, CassandraKeyValueStore.versionTableName)
-//      .withPartitionKey(
-//        CassandraKeyValueStore.namespaceColumnName,
-//        DataTypes.TEXT
-//      )
-//      .withClusteringColumn(
-//        CassandraKeyValueStore.keyColumnName,
-//        DataTypes.BLOB
-//      )
-//      .withColumn(
-//        CassandraKeyValueStore.versionColumnName,
-//        DataTypes.COUNTER
-//      )
-//      .build
-//
-//  object DockerImageTag {
-//    val cassandraV3: String = s"$cassandra:3.11.11"
-//    val cassandraV4: String = s"$cassandra:4.0.1"
-//    val scyllaDb: String =
-//      // This nightly build supports Apple M1; Will point to a regular version when v4.6 is released.
-//      "scylladb/scylla-nightly:4.6.rc1-0.20211227.283788828"
-//  }
-//
-//  val createKeyspaceScript: String =
-//    s"CREATE KEYSPACE $testKeyspaceName WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};"
-//
-//  lazy val cassandraV3: SessionLayer =
-//    cassandraContainer(DockerImageTag.cassandraV3) >>> cassandraSession
-//
-//  lazy val cassandraV4: SessionLayer =
-//    cassandraContainer(DockerImageTag.cassandraV4) >>> cassandraSession
-//
-//  lazy val scyllaDb: SessionLayer =
-//    cassandraContainer(DockerImageTag.scyllaDb) >>> cassandraSession
-//
-//  lazy val cassandraSession: URLayer[CassandraContainer, CqlSession] =
-//    ZLayer.scoped {
-//      for {
-//        container <- ZIO.service[CassandraContainer]
-//        ipAddress <-
-//          ZIO.attempt {
-//            new InetSocketAddress(
-//              container.containerIpAddress,
-//              container.cassandraContainer.getFirstMappedPort
-//            )
-//          }
-//        _ <- createKeyspace(ipAddress)
-//        session <-
-//          ZIO.acquireRelease {
-//            execAsync(
-//              CqlSession.builder
-//                .addContactPoint(ipAddress)
-//                .withKeyspace(
-//                  CqlIdentifier.fromCql(testKeyspaceName)
-//                )
-//                .withLocalDatacenter(testDataCenter)
-//                .buildAsync()
-//            )
-//          } { session =>
-//            attemptBlocking {
-//              session.close()
-//            }.orDie
-//          }
-//      } yield session
-//    }.orDie
-//
-//  def cassandraContainer(imageTag: String): ULayer[CassandraContainer] =
-//    ZLayer.scoped {
-//      ZIO.acquireRelease {
-//        attemptBlocking {
-//          val container =
-//            CassandraContainer(
-//              DockerImageName
-//                .parse(imageTag)
-//                .asCompatibleSubstituteFor(cassandra)
-//            )
-//          container.start()
-//          container
-//        }.orDie
-//      } { container =>
-//        attemptBlocking(
-//          container.stop()
-//        ).orDie
-//      }
-//    }
-//
-//  private def createKeyspace(ipAddress: InetSocketAddress) = ZIO.acquireRelease {
-//    for {
-//      session <-
-//        execAsync(
-//          CqlSession.builder
-//            .addContactPoint(ipAddress)
-//            .withLocalDatacenter(testDataCenter)
-//            .buildAsync()
-//        )
-//      _ <-
-//        execAsync(
-//          session.executeAsync(createKeyspaceScript)
-//        )
-//      _ <-
-//        execAsync(
-//          session.executeAsync(createTable)
-//        )
-//      _ <-
-//        execAsync(
-//          session.executeAsync(createVersionTable)
-//        )
-//    } yield session
-//  } { session =>
-//    attemptBlocking(
-//      session.close()
-//    ).orDie
-//  }
-//}
+package zio.flow.cassandra
+
+import com.datastax.oss.driver.api.core.`type`.DataTypes
+import com.datastax.oss.driver.api.core.{CqlIdentifier, CqlSession}
+import com.datastax.oss.driver.api.querybuilder.SchemaBuilder
+import com.dimafeng.testcontainers.CassandraContainer
+
+import java.net.InetSocketAddress
+import org.testcontainers.utility.DockerImageName
+import zio.{ULayer, URLayer, ZIO, ZLayer}
+import zio.ZIO.{attemptBlocking, fromCompletionStage => execAsync}
+
+/**
+ * A helper module for test-containers integration. Mostly this facilitates
+ * spinning up Cassandra/Scylla containers, then obtaining the container's IP &
+ * port, and finally creating the keyspace and the table for testing.
+ */
+object CassandraTestContainerSupport {
+
+  type SessionLayer = ULayer[CqlSession]
+
+  private val cassandra        = "cassandra"
+  private val testKeyspaceName = "CassandraKeyValueStoreSpec_Keyspace"
+  private val testDataCenter   = "datacenter1"
+
+  private val createTable =
+    SchemaBuilder
+      .createTable(testKeyspaceName, CassandraKeyValueStore.tableName)
+      .withPartitionKey(
+        CassandraKeyValueStore.namespaceColumnName,
+        DataTypes.TEXT
+      )
+      .withClusteringColumn(
+        CassandraKeyValueStore.keyColumnName,
+        DataTypes.BLOB
+      )
+      .withClusteringColumn(
+        CassandraKeyValueStore.timestampColumnName,
+        DataTypes.BIGINT
+      )
+      .withColumn(
+        CassandraKeyValueStore.valueColumnName,
+        DataTypes.BLOB
+      )
+      .build
+
+  object DockerImageTag {
+    val cassandraV3: String = s"$cassandra:3.11.11"
+    val cassandraV4: String = s"$cassandra:4.0.1"
+    val scyllaDb: String =
+      // This nightly build supports Apple M1; Will point to a regular version when v4.6 is released.
+      "scylladb/scylla-nightly:4.6.rc1-0.20211227.283788828"
+  }
+
+  val createKeyspaceScript: String =
+    s"CREATE KEYSPACE $testKeyspaceName WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};"
+
+  lazy val cassandraV3: SessionLayer =
+    cassandraContainer(DockerImageTag.cassandraV3) >>> cassandraSession
+
+  lazy val cassandraV4: SessionLayer =
+    cassandraContainer(DockerImageTag.cassandraV4) >>> cassandraSession
+
+  lazy val scyllaDb: SessionLayer =
+    cassandraContainer(DockerImageTag.scyllaDb) >>> cassandraSession
+
+  lazy val cassandraSession: URLayer[CassandraContainer, CqlSession] =
+    ZLayer.scoped {
+      for {
+        container <- ZIO.service[CassandraContainer]
+        ipAddress <-
+          ZIO.attempt {
+            new InetSocketAddress(
+              container.containerIpAddress,
+              container.cassandraContainer.getFirstMappedPort
+            )
+          }
+        _ <- createKeyspace(ipAddress)
+        session <-
+          ZIO.acquireRelease {
+            execAsync(
+              CqlSession.builder
+                .addContactPoint(ipAddress)
+                .withKeyspace(
+                  CqlIdentifier.fromCql(testKeyspaceName)
+                )
+                .withLocalDatacenter(testDataCenter)
+                .buildAsync()
+            )
+          } { session =>
+            attemptBlocking {
+              session.close()
+            }.orDie
+          }
+      } yield session
+    }.orDie
+
+  def cassandraContainer(imageTag: String): ULayer[CassandraContainer] =
+    ZLayer.scoped {
+      ZIO.acquireRelease {
+        attemptBlocking {
+          val container =
+            CassandraContainer(
+              DockerImageName
+                .parse(imageTag)
+                .asCompatibleSubstituteFor(cassandra)
+            )
+          container.start()
+          container
+        }.orDie
+      } { container =>
+        attemptBlocking(
+          container.stop()
+        ).orDie
+      }
+    }
+
+  private def createKeyspace(ipAddress: InetSocketAddress) = ZIO.acquireRelease {
+    for {
+      session <-
+        execAsync(
+          CqlSession.builder
+            .addContactPoint(ipAddress)
+            .withLocalDatacenter(testDataCenter)
+            .buildAsync()
+        )
+      _ <-
+        execAsync(
+          session.executeAsync(createKeyspaceScript)
+        )
+      _ <-
+        execAsync(
+          session.executeAsync(createTable)
+        )
+
+    } yield session
+  } { session =>
+    attemptBlocking(
+      session.close()
+    ).orDie
+  }
+}

--- a/cassandra/src/main/scala/zio/flow/cassandra/CassandraKeyValueStore.scala
+++ b/cassandra/src/main/scala/zio/flow/cassandra/CassandraKeyValueStore.scala
@@ -1,224 +1,222 @@
-// TODO
-//package zio.flow.cassandra
-//
-//import com.datastax.oss.driver.api.core.cql._
-//import com.datastax.oss.driver.api.core.{CqlIdentifier, CqlSession}
-//import com.datastax.oss.driver.api.querybuilder.QueryBuilder.literal
-//import com.datastax.oss.driver.api.querybuilder.delete.DeleteSelection
-//import com.datastax.oss.driver.api.querybuilder.insert.InsertInto
-//import com.datastax.oss.driver.api.querybuilder.select.SelectFrom
-//import com.datastax.oss.driver.api.querybuilder.{Literal, QueryBuilder}
-//import zio.flow.cassandra.CassandraKeyValueStore._
-//import zio.flow.internal.KeyValueStore
-//import zio.flow.internal.KeyValueStore.Item
-//import zio.stream.ZStream
-//import zio.{Chunk, IO, Task, URLayer, ZIO, ZLayer}
-//
-//import java.io.IOException
-//import java.nio.ByteBuffer
-//
-//final class CassandraKeyValueStore(session: CqlSession) extends KeyValueStore {
-//
-//  private val keyspace =
-//    session.getKeyspace
-//      .orElse(null: CqlIdentifier) // scalafix:ok DisableSyntax.null
-//
-//  private val cqlSelect: SelectFrom =
-//    QueryBuilder.selectFrom(keyspace, table)
-//
-//  private val cqlInsert: InsertInto =
-//    QueryBuilder.insertInto(keyspace, table)
-//
-//  private val cqlDelete: DeleteSelection =
-//    QueryBuilder.deleteFrom(keyspace, table)
-//
-//  override def put(
-//    namespace: String,
-//    key: Chunk[Byte],
-//    value: Chunk[Byte]
-//  ): IO[IOException, Boolean] = {
-//    val insert = toInsert(Item(namespace, key, value))
-//
-//    executeAsync(insert)
-//      .mapBoth(
-//        refineToIOException(s"Error putting key-value pair for <$namespace> namespace"),
-//        _ => true
-//      )
-//  }
-//
-//  override def get(namespace: String, key: Chunk[Byte]): IO[IOException, Option[Chunk[Byte]]] = {
-//    val query = cqlSelect
-//      .column(valueColumnName)
-//      .whereColumn(namespaceColumnName)
-//      .isEqualTo(
-//        literal(namespace)
-//      )
-//      .whereColumn(keyColumnName)
-//      .isEqualTo(
-//        byteBufferFrom(key)
-//      )
-//      .limit(1)
-//      .build
-//
-//    executeAsync(query).flatMap { result =>
-//      if (result.remaining > 0)
-//        ZIO.attempt {
-//          Option(blobValueOf(valueColumnName, result.one))
-//        }
-//      else
-//        ZIO.none
-//    }.mapError(
-//      refineToIOException(s"Error retrieving or reading value for <$namespace> namespace")
-//    )
-//  }
-//
-//  override def scanAll(namespace: String): ZStream[Any, IOException, (Chunk[Byte], Chunk[Byte])] = {
-//    val query = cqlSelect
-//      .column(keyColumnName)
-//      .column(valueColumnName)
-//      .whereColumn(namespaceColumnName)
-//      .isEqualTo(
-//        literal(namespace)
-//      )
-//      .build
-//
-//    lazy val errorContext =
-//      s"Error scanning all key-value pairs for <$namespace> namespace"
-//
-//    ZStream
-//      .paginateZIO(
-//        executeAsync(query)
-//      )(_.map { result =>
-//        val pairs =
-//          ZStream
-//            .fromJavaIterator(
-//              result.currentPage.iterator
-//            )
-//            .mapZIO { row =>
-//              ZIO.attempt {
-//                blobValueOf(keyColumnName, row) -> blobValueOf(valueColumnName, row)
-//              }
-//            }
-//            .mapError(
-//              refineToIOException(errorContext)
-//            )
-//
-//        val nextPage =
-//          if (result.hasMorePages)
-//            Option(
-//              ZIO.fromCompletionStage(result.fetchNextPage())
-//            )
-//          else
-//            None
-//
-//        (pairs, nextPage)
-//      })
-//      .mapError(
-//        refineToIOException(errorContext)
-//      )
-//      .flatten
-//  }
-//
-//  override def delete(namespace: String, key: Chunk[Byte]): IO[IOException, Unit] = {
-//    val delete = cqlDelete
-//      .column(valueColumnName)
-//      .whereColumn(namespaceColumnName)
-//      .isEqualTo(
-//        literal(namespace)
-//      )
-//      .whereColumn(keyColumnName)
-//      .isEqualTo(
-//        byteBufferFrom(key)
-//      )
-//      .build
-//
-//    executeAsync(delete)
-//      .mapBoth(
-//        refineToIOException(s"Error deleting key-value pair from <$namespace> namespace"),
-//        _ => ()
-//      )
-//  }
-//
-//  override def putAll(items: Chunk[KeyValueStore.Item]): IO[IOException, Unit] = {
-//    val batch = new BatchStatementBuilder(BatchType.LOGGED)
-//    batch.addStatements(
-//      items.map(toInsert): _*
-//    )
-//    executeAsync(batch.build())
-//      .mapBoth(
-//        refineToIOException(s"Error putting multiple key-value pairs"),
-//        _ => ()
-//      )
-//  }
-//
-//  private def toInsert(item: KeyValueStore.Item): SimpleStatement =
-//    cqlInsert
-//      .value(
-//        namespaceColumnName,
-//        literal(item.namespace)
-//      )
-//      .value(
-//        keyColumnName,
-//        byteBufferFrom(item.key)
-//      )
-//      .value(
-//        valueColumnName,
-//        byteBufferFrom(item.value)
-//      )
-//      .build
-//
-//  private def executeAsync(statement: Statement[_]): Task[AsyncResultSet] =
-//    ZIO.fromCompletionStage(
-//      session.executeAsync(statement)
-//    )
-//}
-//
-//object CassandraKeyValueStore {
-//
-//  val layer: URLayer[CqlSession, KeyValueStore] =
-//    ZLayer {
-//      ZIO
-//        .service[CqlSession]
-//        .map(new CassandraKeyValueStore(_))
-//    }
-//
-//  private[cassandra] val tableName: String =
-//    withDoubleQuotes("_zflow_key_value_store")
-//
-//  private[cassandra] val namespaceColumnName: String =
-//    withColumnPrefix("namespace")
-//
-//  private[cassandra] val keyColumnName: String =
-//    withColumnPrefix("key")
-//
-//  private[cassandra] val valueColumnName: String =
-//    withColumnPrefix("value")
-//
-//  private val table: CqlIdentifier =
-//    CqlIdentifier.fromCql(tableName)
-//
-//  private def byteBufferFrom(bytes: Chunk[Byte]): Literal =
-//    literal(
-//      ByteBuffer.wrap(bytes.toArray)
-//    )
-//
-//  private def blobValueOf(columnName: String, row: Row): Chunk[Byte] =
-//    Chunk.fromArray(
-//      row
-//        .getByteBuffer(columnName)
-//        .array
-//    )
-//
-//  private def refineToIOException(errorContext: String): Throwable => IOException = {
-//    case error: IOException =>
-//      error
-//    case error =>
-//      new IOException(s"$errorContext: <${error.getMessage}>.", error)
-//  }
-//
-//  private def withColumnPrefix(s: String) =
-//    withDoubleQuotes("zflow_kv_" + s)
-//
-//  private def withDoubleQuotes(string: String) =
-//    "\"" + string + "\""
-//}
+package zio.flow.cassandra
+
+import com.datastax.oss.driver.api.core.cql._
+import com.datastax.oss.driver.api.core.{CqlIdentifier, CqlSession}
+import com.datastax.oss.driver.api.querybuilder.QueryBuilder.literal
+import com.datastax.oss.driver.api.querybuilder.delete.DeleteSelection
+import com.datastax.oss.driver.api.querybuilder.insert.InsertInto
+import com.datastax.oss.driver.api.querybuilder.select.SelectFrom
+import com.datastax.oss.driver.api.querybuilder.{Literal, QueryBuilder}
+import zio.flow.cassandra.CassandraKeyValueStore._
+import zio.flow.internal.KeyValueStore
+import zio.stream.ZStream
+import zio.{Chunk, IO, Task, URLayer, ZIO, ZLayer}
+
+import java.io.IOException
+import java.nio.ByteBuffer
+
+final class CassandraKeyValueStore(session: CqlSession) extends KeyValueStore {
+
+  private val keyspace =
+    session.getKeyspace
+      .orElse(null: CqlIdentifier) // scalafix:ok DisableSyntax.null
+
+  private val cqlSelect: SelectFrom =
+    QueryBuilder.selectFrom(keyspace, table)
+
+  private val cqlInsert: InsertInto =
+    QueryBuilder.insertInto(keyspace, table)
+
+  private val cqlDelete: DeleteSelection =
+    QueryBuilder.deleteFrom(keyspace, table)
+
+  override def put(
+    namespace: String,
+    key: Chunk[Byte],
+    value: Chunk[Byte]
+  ): IO[IOException, Boolean] = {
+    val insert = toInsert(Item(namespace, key, value))
+
+    executeAsync(insert)
+      .mapBoth(
+        refineToIOException(s"Error putting key-value pair for <$namespace> namespace"),
+        _ => true
+      )
+  }
+
+  override def get(namespace: String, key: Chunk[Byte]): IO[IOException, Option[Chunk[Byte]]] = {
+    val query = cqlSelect
+      .column(valueColumnName)
+      .whereColumn(namespaceColumnName)
+      .isEqualTo(
+        literal(namespace)
+      )
+      .whereColumn(keyColumnName)
+      .isEqualTo(
+        byteBufferFrom(key)
+      )
+      .limit(1)
+      .build
+
+    executeAsync(query).flatMap { result =>
+      if (result.remaining > 0)
+        ZIO.attempt {
+          Option(blobValueOf(valueColumnName, result.one))
+        }
+      else
+        ZIO.none
+    }.mapError(
+      refineToIOException(s"Error retrieving or reading value for <$namespace> namespace")
+    )
+  }
+
+  override def scanAll(namespace: String): ZStream[Any, IOException, (Chunk[Byte], Chunk[Byte])] = {
+    val query = cqlSelect
+      .column(keyColumnName)
+      .column(valueColumnName)
+      .whereColumn(namespaceColumnName)
+      .isEqualTo(
+        literal(namespace)
+      )
+      .build
+
+    lazy val errorContext =
+      s"Error scanning all key-value pairs for <$namespace> namespace"
+
+    ZStream
+      .paginateZIO(
+        executeAsync(query)
+      )(_.map { result =>
+        val pairs =
+          ZStream
+            .fromJavaIterator(
+              result.currentPage.iterator
+            )
+            .mapZIO { row =>
+              ZIO.attempt {
+                blobValueOf(keyColumnName, row) -> blobValueOf(valueColumnName, row)
+              }
+            }
+            .mapError(
+              refineToIOException(errorContext)
+            )
+
+        val nextPage =
+          if (result.hasMorePages)
+            Option(
+              ZIO.fromCompletionStage(result.fetchNextPage())
+            )
+          else
+            None
+
+        (pairs, nextPage)
+      })
+      .mapError(
+        refineToIOException(errorContext)
+      )
+      .flatten
+  }
+
+  override def delete(namespace: String, key: Chunk[Byte]): IO[IOException, Unit] = {
+    val delete = cqlDelete
+      .column(valueColumnName)
+      .whereColumn(namespaceColumnName)
+      .isEqualTo(
+        literal(namespace)
+      )
+      .whereColumn(keyColumnName)
+      .isEqualTo(
+        byteBufferFrom(key)
+      )
+      .build
+
+    executeAsync(delete)
+      .mapBoth(
+        refineToIOException(s"Error deleting key-value pair from <$namespace> namespace"),
+        _ => ()
+      )
+  }
+
+  override def putAll(items: Chunk[KeyValueStore.Item]): IO[IOException, Unit] = {
+    val batch = new BatchStatementBuilder(BatchType.LOGGED)
+    batch.addStatements(
+      items.map(toInsert): _*
+    )
+    executeAsync(batch.build())
+      .mapBoth(
+        refineToIOException(s"Error putting multiple key-value pairs"),
+        _ => ()
+      )
+  }
+
+  private def toInsert(item: KeyValueStore.Item): SimpleStatement =
+    cqlInsert
+      .value(
+        namespaceColumnName,
+        literal(item.namespace)
+      )
+      .value(
+        keyColumnName,
+        byteBufferFrom(item.key)
+      )
+      .value(
+        valueColumnName,
+        byteBufferFrom(item.value)
+      )
+      .build
+
+  private def executeAsync(statement: Statement[_]): Task[AsyncResultSet] =
+    ZIO.fromCompletionStage(
+      session.executeAsync(statement)
+    )
+}
+
+object CassandraKeyValueStore {
+
+  val layer: URLayer[CqlSession, KeyValueStore] =
+    ZLayer {
+      ZIO
+        .service[CqlSession]
+        .map(new CassandraKeyValueStore(_))
+    }
+
+  private[cassandra] val tableName: String =
+    withDoubleQuotes("_zflow_key_value_store")
+
+  private[cassandra] val namespaceColumnName: String =
+    withColumnPrefix("namespace")
+
+  private[cassandra] val keyColumnName: String =
+    withColumnPrefix("key")
+
+  private[cassandra] val valueColumnName: String =
+    withColumnPrefix("value")
+
+  private val table: CqlIdentifier =
+    CqlIdentifier.fromCql(tableName)
+
+  private def byteBufferFrom(bytes: Chunk[Byte]): Literal =
+    literal(
+      ByteBuffer.wrap(bytes.toArray)
+    )
+
+  private def blobValueOf(columnName: String, row: Row): Chunk[Byte] =
+    Chunk.fromArray(
+      row
+        .getByteBuffer(columnName)
+        .array
+    )
+
+  private def refineToIOException(errorContext: String): Throwable => IOException = {
+    case error: IOException =>
+      error
+    case error =>
+      new IOException(s"$errorContext: <${error.getMessage}>.", error)
+  }
+
+  private def withColumnPrefix(s: String) =
+    withDoubleQuotes("zflow_kv_" + s)
+
+  private def withDoubleQuotes(string: String) =
+    "\"" + string + "\""
+}

--- a/docs/modules/CassandraKvStore.md
+++ b/docs/modules/CassandraKvStore.md
@@ -15,12 +15,13 @@ The Cassandra module requires a table (column family) for persistence. To create
 CREATE TABLE _zflow_key_value_store (
   zflow_kv_namespace  VARCHAR,
   zflow_kv_key        BLOB,
+  zflow_kv_timestamp  BIGINT,
   zflow_kv_value      BLOB,
-  PRIMARY KEY (zflow_kv_namespace, zflow_kv_key)
+  PRIMARY KEY (zflow_kv_namespace, zflow_kv_key, zflow_kv_timestamp)
 );
 ```
 You should add table options to this statement in a production environment for tuning. Please consult the official documentations of the database product of your choosing. 
 
 # Performance/Scaling Considerations:
 
-As you can see from the CQL above, the primary key is composed of the two columns, `zflow_kv_namespace` and `zflow_kv_key`. In particular, `zflow_kv_namespace` is the partition key and `zflow_kv_key` is the clustering key. Assuming the default partitioner (Murmur3Partitioner) is used, data will be partitioned by the hash values of the `zflow_kv_namespace` column. If one small set of namespace values are the majority for all possible values, that will create data skew and can have a big impact to your cluster down the road. Some consideration is needed when deciding the type of values `zflow_kv_namespace` should store.
+As you can see from the CQL above, the primary key is composed of the three columns, `zflow_kv_namespace`, `zflow_kv_key` and `zflow_kv_timestamp`. In particular, `zflow_kv_namespace` is the partition key and `zflow_kv_key` and `zflow_kv_timestamp` are the clustering keys. Assuming the default partitioner (Murmur3Partitioner) is used, data will be partitioned by the hash values of the `zflow_kv_namespace` column. If one small set of namespace values are the majority for all possible values, that will create data skew and can have a big impact to your cluster down the road. Some consideration is needed when deciding the type of values `zflow_kv_namespace` should store.

--- a/zio-flow/shared/src/main/scala/zio/flow/internal/KeyValueStore.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/internal/KeyValueStore.scala
@@ -66,6 +66,11 @@ object KeyValueStore {
       _.scanAll(namespace)
     )
 
+  def delete(namespace: String, key: Chunk[Byte]): ZIO[KeyValueStore, IOException, Unit] =
+    ZIO.serviceWithZIO(
+      _.delete(namespace, key)
+    )
+
   private final case class InMemoryKeyValueEntry(data: Chunk[Byte], timestamp: Timestamp) {
     override def toString: String = s"<entry ($data.size bytes) at $timestamp>"
   }


### PR DESCRIPTION
One note: deleting a range of values (all timestamps) is not possible with Cassandra, so first we have to get a list of all timestamps and then execute a batch delete operation on all of these. I don't think this needs transactional functionality, however, as the calls to these delete functions should already be strictly controlled, and not executed concurrently. 