### PR TITLE
Http operation impl

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,9 @@ lazy val zioFlow = crossProject(JSPlatform, JVMPlatform)
       "dev.zio" %% "zio-schema-derivation" % Version.zioSchema,
       "dev.zio" %% "zio-schema-optics"     % Version.zioSchema,
       "dev.zio" %% "zio-schema-json"       % Version.zioSchema,
-      "dev.zio" %% "zio-schema-protobuf"   % Version.zioSchema
+      "dev.zio" %% "zio-schema-protobuf"   % Version.zioSchema,
+      "io.d11"  %% "zhttp"                 % Version.zioHttp,
+      "io.d11"  %% "zhttp-test"            % Version.zioHttp % Test
     ) ++
       commonTestDependencies.map(_ % Test)
   )

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -13,5 +13,5 @@ object Version {
   val cassandraJavaDriver = "4.13.0.0"
   val rocksDbJni          = "7.2.2"
   val testContainers      = "0.40.5"
-  val zioHttp             = "1.0.0.0-RC27"
+  val zioHttp             = "2.0.0-RC7"
 }

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -13,4 +13,5 @@ object Version {
   val cassandraJavaDriver = "4.13.0.0"
   val rocksDbJni          = "7.2.2"
   val testContainers      = "0.40.5"
+  val zioHttp             = "1.0.0.0-RC27"
 }

--- a/zio-flow-examples/shared/src/main/scala/zio/flow/examples/HttpExample.scala
+++ b/zio-flow-examples/shared/src/main/scala/zio/flow/examples/HttpExample.scala
@@ -1,8 +1,7 @@
 package zio.flow.examples
 
 import zio.flow._
-import zio.schema.{DeriveSchema, Schema}
-import zio.{Scope, ZIO, ZIOAppArgs}
+import zio.schema.Schema
 import zio.flow.operation.http.API
 import zio.flow.operation.http._
 

--- a/zio-flow-examples/shared/src/main/scala/zio/flow/examples/HttpExample.scala
+++ b/zio-flow-examples/shared/src/main/scala/zio/flow/examples/HttpExample.scala
@@ -1,0 +1,35 @@
+package zio.flow.examples
+
+import zio.flow._
+import zio.schema.{DeriveSchema, Schema}
+import zio.{Scope, ZIO, ZIOAppArgs}
+import zio.flow.operation.http.API
+import zio.flow.operation.http._
+
+import zio.json.JsonCodec
+
+object HttpFlowExample {
+
+  case class UserData(name: String)
+
+  implicit val userDataSchema: Schema[UserData]       = ???
+  implicit val userDataJsonCodec: JsonCodec[UserData] = ???
+
+  val setUserData = Activity[(Int, UserData), Unit](
+    "setUserData",
+    "set user data",
+    Operation.Http(
+      "https://example.com",
+      API.post("users" / int).input[UserData]
+    ),
+    check = ???,
+    compensate = ZFlow.succeed(())
+  )
+
+  val flow = for {
+    id   <- ZFlow.succeed(1)
+    data <- ZFlow.succeed(UserData("Albert"))
+    _    <- setUserData(id, data)
+  } yield ()
+
+}

--- a/zio-flow/shared/src/main/scala/zio/flow/Operation.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/Operation.scala
@@ -26,36 +26,15 @@ sealed trait Operation[-R, +A] {
 
 object Operation {
   final case class Http[R, A](
-    url: java.net.URI,
-    method: String = "GET",
-    headers: Map[String, String],
-    inputSchema: Schema[R],
-    resultSchema: Schema[A]
-  ) extends Operation[R, A]
+    host: String,
+    api: zio.flow.operation.http.API[R, A]
+  ) extends Operation[R, A] {
+    override val inputSchema: Schema[_ >: R]  = ???
+    override val resultSchema: Schema[_ <: A] = api.outputSchema
+  }
 
   object Http {
-    def schema[R, A]: Schema[Http[R, A]] =
-      Schema.CaseClass5[java.net.URI, String, Map[String, String], FlowSchemaAst, FlowSchemaAst, Http[R, A]](
-        Schema.Field("url", Schema[java.net.URI]),
-        Schema.Field("method", Schema[String]),
-        Schema.Field("headers", Schema.map[String, String]),
-        Schema.Field("inputSchema", FlowSchemaAst.schema),
-        Schema.Field("outputSchema", FlowSchemaAst.schema),
-        { case (url, method, headers, inputSchemaAst, outputSchemaAst) =>
-          Http(
-            url,
-            method,
-            headers,
-            inputSchemaAst.toSchema[R],
-            outputSchemaAst.toSchema[A]
-          )
-        },
-        _.url,
-        _.method,
-        _.headers,
-        op => FlowSchemaAst.fromSchema(op.inputSchema),
-        op => FlowSchemaAst.fromSchema(op.resultSchema)
-      )
+    def schema[R, A]: Schema[Http[R, A]] = ???
 
     def schemaCase[R, A]: Schema.Case[Http[R, A], Operation[R, A]] =
       Schema.Case("Http", schema[R, A], _.asInstanceOf[Http[R, A]])

--- a/zio-flow/shared/src/main/scala/zio/flow/Operation.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/Operation.scala
@@ -61,27 +61,10 @@ object Operation {
       Schema.Case("Http", schema[R, A], _.asInstanceOf[Http[R, A]])
   }
 
-  final case class SendEmail(
-    server: String,
-    port: Int
-  ) extends Operation[EmailRequest, Unit] {
-
-    override val inputSchema  = Schema[EmailRequest]
-    override val resultSchema = Schema[Unit]
-  }
-
-  object SendEmail {
-    val schema: Schema[SendEmail] = DeriveSchema.gen
-
-    def schemaCase[R, A]: Schema.Case[SendEmail, Operation[R, A]] =
-      Schema.Case("SendEmail", schema, _.asInstanceOf[SendEmail])
-  }
-
   implicit def schema[R, A]: Schema[Operation[R, A]] =
     Schema.EnumN(
       CaseSet
         .Cons(Http.schemaCase[R, A], CaseSet.Empty[Operation[R, A]]())
-        .:+:(SendEmail.schemaCase[R, A])
     )
 }
 

--- a/zio-flow/shared/src/main/scala/zio/flow/OperationExecutor.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/OperationExecutor.scala
@@ -18,6 +18,9 @@ package zio.flow
 
 import zio.{ZEnvironment, ZIO}
 import zio.flow.Operation.Http
+import zio.flow.operation.http._
+import zhttp.service.EventLoopGroup
+import zhttp.service.ChannelFactory
 
 /**
  * An `OperationExecutor` can execute operations, or fail trying.
@@ -34,11 +37,10 @@ trait OperationExecutor[-R] { self =>
     }
 }
 
-// case class OperationExecutorImpl() extends OperationExecutor[Any] {
-//   override def execute[I, A](input: I, operation: Operation[I,A]): ZIO[R, ActivityError, A] = {
-//     operation match {
-//       case Http(url, method, headers, inputSchema, resultSchema) => 
-//       case SendEmail(server, port) => ???
-//     }
-//   }
-// }
+case class OperationExecutorImpl() extends OperationExecutor[EventLoopGroup with ChannelFactory] {
+  override def execute[I, A](input: I, operation: Operation[I,A]): ZIO[EventLoopGroup with ChannelFactory, ActivityError, A] = {
+    operation match {
+      case Http(host, api) => api.call(host)(input).mapError(e => ActivityError(e.getMessage(), Option(e)))
+    }
+  }
+}

--- a/zio-flow/shared/src/main/scala/zio/flow/OperationExecutor.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/OperationExecutor.scala
@@ -38,9 +38,11 @@ trait OperationExecutor[-R] { self =>
 }
 
 case class OperationExecutorImpl() extends OperationExecutor[EventLoopGroup with ChannelFactory] {
-  override def execute[I, A](input: I, operation: Operation[I,A]): ZIO[EventLoopGroup with ChannelFactory, ActivityError, A] = {
+  override def execute[I, A](
+    input: I,
+    operation: Operation[I, A]
+  ): ZIO[EventLoopGroup with ChannelFactory, ActivityError, A] =
     operation match {
       case Http(host, api) => api.call(host)(input).mapError(e => ActivityError(e.getMessage(), Option(e)))
     }
-  }
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/OperationExecutor.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/OperationExecutor.scala
@@ -17,6 +17,7 @@
 package zio.flow
 
 import zio.{ZEnvironment, ZIO}
+import zio.flow.Operation.Http
 
 /**
  * An `OperationExecutor` can execute operations, or fail trying.
@@ -32,3 +33,12 @@ trait OperationExecutor[-R] { self =>
         self.execute(input, operation).provideEnvironment(env)
     }
 }
+
+// case class OperationExecutorImpl() extends OperationExecutor[Any] {
+//   override def execute[I, A](input: I, operation: Operation[I,A]): ZIO[R, ActivityError, A] = {
+//     operation match {
+//       case Http(url, method, headers, inputSchema, resultSchema) => 
+//       case SendEmail(server, port) => ???
+//     }
+//   }
+// }

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/Api.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/Api.scala
@@ -81,7 +81,7 @@ object API {
   /**
    * Creates an API with the given method and path.
    */
-  private def method[Params](method: HttpMethod, path: Path[Params] = ""): API[Params, Unit] =
+  private def method[Params](method: HttpMethod, path: Path[Params]): API[Params, Unit] =
     API(method, path, Schema[Unit])
 
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/Api.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/Api.scala
@@ -57,31 +57,31 @@ object API {
   /**
    * Creates an API for DELETE request at the given path.
    */
-  def delete[A](path: Path[A]): API[A, Unit] =
+  def delete[A](path: Path[A] = ""): API[A, Unit] =
     method(HttpMethod.DELETE, path)
 
   /**
    * Creates an API for a GET request at the given path.
    */
-  def get[A](path: Path[A]): API[A, Unit] =
+  def get[A](path: Path[A] = ""): API[A, Unit] =
     method(HttpMethod.GET, path)
 
   /**
    * Creates an API for a POST request at the given path.
    */
-  def post[A](path: Path[A]): API[A, Unit] =
+  def post[A](path: Path[A] = ""): API[A, Unit] =
     method(HttpMethod.POST, path)
 
   /**
    * Creates an API for a PUT request at the given path.
    */
-  def put[A](path: Path[A]): API[A, Unit] =
+  def put[A](path: Path[A] = ""): API[A, Unit] =
     method(HttpMethod.PUT, path)
 
   /**
    * Creates an API with the given method and path.
    */
-  private def method[Params](method: HttpMethod, path: Path[Params]): API[Params, Unit] =
+  private def method[Params](method: HttpMethod, path: Path[Params] = ""): API[Params, Unit] =
     API(method, path, Schema[Unit])
 
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/Api.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/Api.scala
@@ -1,38 +1,47 @@
 package zio.flow.operation.http
 
 import zhttp.http.{Headers => _, Path => _}
-import zio.json._
 import zio.schema.Schema
-import zio.Unzippable
+import zio.flow.serialization.FlowSchemaAst
 
-/**   - Input and Output as Schemas.
-  *   - Support wide range of Codecs including Json
-  *     - Dynamically decide response format based upon Request Header
-  */
+/**
+ *   - Input and Output as Schemas.
+ *   - Dynamically decide response format based upon Request Header
+ */
 final case class API[Input, Output](
-    method: HttpMethod,
-    requestInput: RequestInput[Input], // Path / QueryParams / Headers / Body
-    outputCodec: JsonCodec[Output],
-    outputSchema: Schema[Output]
+  method: HttpMethod,
+  requestInput: RequestInput[Input], // Path / QueryParams / Headers / Body
+  outputSchema: Schema[Output]
 ) { self =>
   type Id
 
   def query[A](queryParams: Query[A])(implicit
-      unzippable: Unzippable[Input, A]
-  ): API[unzippable.In, Output] =
+    zipper: Zipper[Input, A]
+  ): API[zipper.Out, Output] =
     copy(requestInput = requestInput ++ queryParams)
 
-  def header[A](headers: Header[A])(implicit unzippable: Unzippable[Input, A]): API[unzippable.In, Output] =
+  def header[A](headers: Header[A])(implicit zipper: Zipper[Input, A]): API[zipper.Out, Output] =
     copy(requestInput = requestInput ++ headers)
 
-  def input[A](implicit codec: JsonCodec[A], schema: Schema[A], unzippable: Unzippable[Input, A]): API[unzippable.In, Output] =
-    copy(requestInput = requestInput ++ Body(codec, schema))
+  def input[A](implicit schema: Schema[A], zipper: Zipper[Input, A]): API[zipper.Out, Output] =
+    copy(requestInput = requestInput ++ Body(schema))
 
-  def output[Output2](implicit codec: JsonCodec[Output2], schema: Schema[Output2]): API[Input, Output2] =
-    copy(outputCodec = codec, outputSchema = schema)
+  def output[Output2](implicit schema: Schema[Output2]): API[Input, Output2] =
+    copy(outputSchema = schema)
 }
 
 object API {
+
+  def schema[Input, Output]: Schema[API[Input, Output]] =
+    Schema.CaseClass3[HttpMethod, RequestInput[Input], FlowSchemaAst, API[Input, Output]](
+      Schema.Field("method", HttpMethod.schema),
+      Schema.Field("requestInput", RequestInput.schema[Input]),
+      Schema.Field("outputSchema", FlowSchemaAst.schema),
+      (method, requestInput, outputSchema) => API(method, requestInput, outputSchema.toSchema[Output]),
+      _.method,
+      _.requestInput,
+      api => FlowSchemaAst.fromSchema(api.outputSchema)
+    )
 
   type WithId[Input, Output, Id0] = API[Input, Output] { type Id = Id0 }
 
@@ -45,29 +54,34 @@ object API {
     implicit val notUnitUnit2: NotUnit[Unit] = new NotUnit[Unit] {}
   }
 
-  /** Creates an API for DELETE request at the given path.
-    */
+  /**
+   * Creates an API for DELETE request at the given path.
+   */
   def delete[A](path: Path[A]): API[A, Unit] =
     method(HttpMethod.DELETE, path)
 
-  /** Creates an API for a GET request at the given path.
-    */
+  /**
+   * Creates an API for a GET request at the given path.
+   */
   def get[A](path: Path[A]): API[A, Unit] =
     method(HttpMethod.GET, path)
 
-  /** Creates an API for a POST request at the given path.
-    */
+  /**
+   * Creates an API for a POST request at the given path.
+   */
   def post[A](path: Path[A]): API[A, Unit] =
     method(HttpMethod.POST, path)
 
-  /** Creates an API for a PUT request at the given path.
-    */
+  /**
+   * Creates an API for a PUT request at the given path.
+   */
   def put[A](path: Path[A]): API[A, Unit] =
     method(HttpMethod.PUT, path)
 
-  /** Creates an API with the given method and path.
-    */
+  /**
+   * Creates an API with the given method and path.
+   */
   private def method[Params](method: HttpMethod, path: Path[Params]): API[Params, Unit] =
-    API(method, path, unitCodec, Schema[Unit])
+    API(method, path, Schema[Unit])
 
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/Api.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/Api.scala
@@ -1,0 +1,73 @@
+package zio.flow.operation.http
+
+import zhttp.http.{Headers => _, Path => _}
+import zio.json._
+import zio.schema.Schema
+import zio.Unzippable
+
+/**   - Input and Output as Schemas.
+  *   - Support wide range of Codecs including Json
+  *     - Dynamically decide response format based upon Request Header
+  */
+final case class API[Input, Output](
+    method: HttpMethod,
+    requestInput: RequestInput[Input], // Path / QueryParams / Headers / Body
+    outputCodec: JsonCodec[Output],
+    outputSchema: Schema[Output]
+) { self =>
+  type Id
+
+  def query[A](queryParams: Query[A])(implicit
+      unzippable: Unzippable[Input, A]
+  ): API[unzippable.In, Output] =
+    copy(requestInput = requestInput ++ queryParams)
+
+  def header[A](headers: Header[A])(implicit unzippable: Unzippable[Input, A]): API[unzippable.In, Output] =
+    copy(requestInput = requestInput ++ headers)
+
+  def input[A](implicit codec: JsonCodec[A], schema: Schema[A], unzippable: Unzippable[Input, A]): API[unzippable.In, Output] =
+    copy(requestInput = requestInput ++ Body(codec, schema))
+
+  def output[Output2](implicit codec: JsonCodec[Output2], schema: Schema[Output2]): API[Input, Output2] =
+    copy(outputCodec = codec, outputSchema = schema)
+}
+
+object API {
+
+  type WithId[Input, Output, Id0] = API[Input, Output] { type Id = Id0 }
+
+  trait NotUnit[A]
+
+  object NotUnit {
+    implicit def notUnit[A]: NotUnit[A] = new NotUnit[A] {}
+
+    implicit val notUnitUnit1: NotUnit[Unit] = new NotUnit[Unit] {}
+    implicit val notUnitUnit2: NotUnit[Unit] = new NotUnit[Unit] {}
+  }
+
+  /** Creates an API for DELETE request at the given path.
+    */
+  def delete[A](path: Path[A]): API[A, Unit] =
+    method(HttpMethod.DELETE, path)
+
+  /** Creates an API for a GET request at the given path.
+    */
+  def get[A](path: Path[A]): API[A, Unit] =
+    method(HttpMethod.GET, path)
+
+  /** Creates an API for a POST request at the given path.
+    */
+  def post[A](path: Path[A]): API[A, Unit] =
+    method(HttpMethod.POST, path)
+
+  /** Creates an API for a PUT request at the given path.
+    */
+  def put[A](path: Path[A]): API[A, Unit] =
+    method(HttpMethod.PUT, path)
+
+  /** Creates an API with the given method and path.
+    */
+  private def method[Params](method: HttpMethod, path: Path[Params]): API[Params, Unit] =
+    API(method, path, unitCodec, Schema[Unit])
+
+}

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/ApiOps.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/ApiOps.scala
@@ -1,0 +1,23 @@
+package zio.flow.operation.http
+
+import zio.ZIO
+import zhttp.service.EventLoopGroup
+import zhttp.service.ChannelFactory
+import zio.schema.codec.JsonCodec
+
+final class APIOps[Input, Output: API.NotUnit, Id](
+  val self: API.WithId[Input, Output, Id]
+) {
+  def call(host: String)(params: Input): ZIO[EventLoopGroup with ChannelFactory, Throwable, Output] =
+    ClientInterpreter.interpret(host)(self)(params).flatMap(_.body).flatMap { string =>
+      JsonCodec.decode(self.outputSchema)(string) match {
+        case Left(err)    => ZIO.fail(new Error(s"Could not parse response: $err"))
+        case Right(value) => ZIO.succeed(value)
+      }
+    }
+}
+
+final class APIOpsUnit[Input, Id](val self: API.WithId[Input, Unit, Id]) {
+  def call(host: String)(params: Input): ZIO[EventLoopGroup with ChannelFactory, Throwable, Unit] =
+    ClientInterpreter.interpret(host)(self)(params).unit
+}

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/ClientInterpreter.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/ClientInterpreter.scala
@@ -1,0 +1,135 @@
+package zio.flow.operation.http
+
+import zhttp.http.HttpData
+import zhttp.service.{ChannelFactory, Client, EventLoopGroup}
+import zio.ZIO
+
+import scala.collection.mutable
+import zhttp.http.Response
+import zio.Chunk
+
+private[http] object ClientInterpreter {
+  def interpret[Input, Output](host: String)(
+      api: API[Input, Output]
+  )(input: Input): ZIO[EventLoopGroup with ChannelFactory, Throwable, Response] = {
+    val method = api.method.toZioHttpMethod
+    val state  = new RequestState()
+    parseUrl(api.requestInput, state)(input)
+    val (url, headers, body) = state.result
+    val data = body.fold(HttpData.empty)(HttpData.fromChunk)
+    Client.request(s"$host$url", method, zhttp.http.Headers(headers.toList), content = data)
+  }
+
+  private[http] class RequestState {
+    private val query: mutable.Map[String, String]   = mutable.Map.empty
+    private val headers: mutable.Map[String, String] = mutable.Map.empty
+    private val pathBuilder: StringBuilder           = new StringBuilder()
+    private var body: Option[Chunk[Byte]]            = None
+
+    def addPath(path: String): Unit =
+      pathBuilder.addAll(path)
+
+    def addQuery(key: String, value: String): Unit =
+      query.put(key, value)
+
+    def addHeader(key: String, value: String): Unit =
+      headers.put(key, value)
+
+    def setBody(body: Chunk[Byte]): Unit =
+      this.body = Option(body)
+
+    def result: (String, Map[String, String], Option[Chunk[Byte]]) = {
+
+      val queryString =
+        if (query.nonEmpty)
+          query.map { case (key, value) => s"$key=$value" }.mkString("?", "&", "")
+        else
+          ""
+
+      (pathBuilder.result + queryString, headers.toMap, body)
+    }
+  }
+
+  private[http] def parseUrl[Params](
+      requestInput: RequestInput[Params],
+      state: RequestState
+  )(params: Params): Unit =
+    requestInput match {
+      case RequestInput.ZipWith(left, right, g) =>
+        g(params) match {
+          case (a, b) =>
+            parseUrl(left, state)(a)
+            parseUrl(right, state)(b)
+        }
+      case headers: Header[_] =>
+        parseHeaders[Params](headers, state)(params)
+
+      case query: Query[_] =>
+        parseQuery[Params](query, state)(params)
+
+      case route: Path[_] =>
+        parsePath[Params](route, state)(params)
+    }
+
+  private def parsePath[Params](
+      route: Path[Params],
+      state: RequestState
+  )(params: Params): Unit =
+    route match {
+      case Path.ZipWith(left, right, g) =>
+        g(params) match {
+          case (a, b) =>
+            parsePath(left, state)(a)
+            parsePath(right, state)(b)
+        }
+      case Path.Literal(literal) =>
+        state.addPath("/" + literal)
+      case Path.Match(_, _) =>
+        state.addPath("/" + params.toString)
+    }
+
+  private def parseQuery[Params](
+      query: Query[Params],
+      state: RequestState
+  )(params: Params): Unit =
+    query match {
+      case Query.SingleParam(name, _) =>
+        state.addQuery(name, params.toString)
+      case Query.Optional(p) =>
+        params match {
+          case Some(params) =>
+            parseQuery(p, state)(params)
+          case None =>
+            ()
+        }
+
+      case Query.ZipWith(left, right, g) =>
+        g(params) match {
+          case (a, b) =>
+            parseQuery(left, state)(a)
+            parseQuery(right, state)(b)
+        }
+    }
+
+  private def parseHeaders[Params](
+      headers: Header[Params],
+      state: RequestState
+  )(params: Params): Unit =
+    headers match {
+      case Header.ZipWith(left, right, g) =>
+        g(params) match {
+          case (a, b) =>
+            parseHeaders(left, state)(a)
+            parseHeaders(right, state)(b)
+        }
+      case Header.Optional(headers) =>
+        params match {
+          case Some(params) =>
+            parseHeaders(headers, state)(params)
+          case None =>
+            ()
+        }
+      case Header.SingleHeader(name) =>
+        state.addHeader(name, params.toString)
+    }
+}

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/ClientInterpreter.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/ClientInterpreter.scala
@@ -100,7 +100,7 @@ private[http] object ClientInterpreter {
       case Query.SingleParam(name, _) =>
         state.addQuery(name, params.toString)
       case Query.Optional(p) =>
-        params match {
+        params.asInstanceOf[Option[Any]] match {
           case Some(params) =>
             parseQuery(p, state)(params)
           case None =>
@@ -127,7 +127,7 @@ private[http] object ClientInterpreter {
             parseHeaders(right, state)(b)
         }
       case Header.Optional(headers) =>
-        params match {
+        params.asInstanceOf[Option[Any]] match {
           case Some(params) =>
             parseHeaders(headers, state)(params)
           case None =>

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/ClientInterpreter.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/ClientInterpreter.scala
@@ -30,10 +30,10 @@ private[http] object ClientInterpreter {
     def addPath(path: String): Unit =
       pathBuilder.addAll(path)
 
-    def addQuery(key: String, value: String): Unit =
+    def addQuery(key: String, value: String): Option[String] =
       query.put(key, value)
 
-    def addHeader(key: String, value: String): Unit =
+    def addHeader(key: String, value: String): Option[String] =
       headers.put(key, value)
 
     def setBody(body: Chunk[Byte]): Unit =
@@ -54,7 +54,7 @@ private[http] object ClientInterpreter {
   private[http] def parseUrl[Params](
     requestInput: RequestInput[Params],
     state: RequestState
-  )(params: Params): Unit =
+  )(params: Params): Any =
     requestInput match {
       case RequestInput.ZipWith(left, right, zipper) =>
         zipper.unzip(params) match {
@@ -95,7 +95,7 @@ private[http] object ClientInterpreter {
   private def parseQuery[Params](
     query: Query[Params],
     state: RequestState
-  )(params: Params): Unit =
+  )(params: Params): Any =
     query match {
       case Query.SingleParam(name, _) =>
         state.addQuery(name, params.toString)
@@ -118,7 +118,7 @@ private[http] object ClientInterpreter {
   private def parseHeaders[Params](
     headers: Header[Params],
     state: RequestState
-  )(params: Params): Unit =
+  )(params: Params): Any =
     headers match {
       case Header.ZipWith(left, right, zipper) =>
         zipper.unzip(params) match {

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/ClientInterpreter.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/ClientInterpreter.scala
@@ -28,7 +28,7 @@ private[http] object ClientInterpreter {
     private var body: Option[Chunk[Byte]]            = None
 
     def addPath(path: String): Unit =
-      pathBuilder.addAll(path)
+      pathBuilder ++= path
 
     def addQuery(key: String, value: String): Option[String] =
       query.put(key, value)

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/HttpMethod.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/HttpMethod.scala
@@ -1,0 +1,20 @@
+package zio.flow.operation.http
+
+sealed trait HttpMethod extends Product with Serializable { self =>
+  def toZioHttpMethod: zhttp.http.Method =
+    self match {
+      case HttpMethod.GET    => zhttp.http.Method.GET
+      case HttpMethod.POST   => zhttp.http.Method.POST
+      case HttpMethod.PATCH  => zhttp.http.Method.PATCH
+      case HttpMethod.PUT    => zhttp.http.Method.PUT
+      case HttpMethod.DELETE => zhttp.http.Method.DELETE
+    }
+}
+
+object HttpMethod {
+  case object GET    extends HttpMethod
+  case object POST   extends HttpMethod
+  case object PATCH  extends HttpMethod
+  case object PUT    extends HttpMethod
+  case object DELETE extends HttpMethod
+}

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/HttpMethod.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/HttpMethod.scala
@@ -1,5 +1,8 @@
 package zio.flow.operation.http
 
+import zio.schema.DeriveSchema
+import zio.schema.Schema
+
 sealed trait HttpMethod extends Product with Serializable { self =>
   def toZioHttpMethod: zhttp.http.Method =
     self match {
@@ -12,6 +15,9 @@ sealed trait HttpMethod extends Product with Serializable { self =>
 }
 
 object HttpMethod {
+
+  val schema: Schema[HttpMethod] = DeriveSchema.gen[HttpMethod]
+
   case object GET    extends HttpMethod
   case object POST   extends HttpMethod
   case object PATCH  extends HttpMethod

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/Path.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/Path.scala
@@ -1,41 +1,80 @@
 package zio.flow.operation.http
 
-import zhttp.http.{Request, Header => ZHeader}
 import zio.schema.Schema
 
-import scala.language.implicitConversions
-import zio.Zippable
-import zio.Unzippable
-import zio.json.JsonCodec
+import zio.schema.CaseSet
+import zio.flow.serialization.FlowSchemaAst
+import zio.schema.DeriveSchema
 
-/** A RequestInput is a description of a Path, Query Parameters, and Headers and Body
-  *   - Path: /users/:id/posts
-  *   - Query Parameters: ?page=1&limit=10
-  *   - Headers: X-User-Id: 1 or Accept: application/json
-  */
+/**
+ * A RequestInput is a description of a Path, Query Parameters, Headers and Body
+ *   - Path: /users/:id/posts
+ *   - Query Parameters: ?page=1&limit=10
+ *   - Headers: X-User-Id: 1 or Accept: application/json
+ *   - Body: anything that has a schema
+ */
 sealed trait RequestInput[A] extends Product with Serializable { self =>
-  private[http] def ++[B](that: RequestInput[B])(implicit unzipper: Unzippable[A, B]): RequestInput[unzipper.In] =
-    RequestInput.ZipWith[A, B, unzipper.In](self, that, unzipper.unzip)
+  def schema: Schema[A]
+
+  private[http] def ++[B](that: RequestInput[B])(implicit zipper: Zipper[A, B]): RequestInput[zipper.Out] =
+    RequestInput.ZipWith[A, B, zipper.Out](self, that, zipper)
 }
 
 object RequestInput {
+
+  def schema[A]: Schema[RequestInput[A]] = Schema.EnumN(
+    CaseSet
+      .Cons(ZipWith.schemaCase[A], CaseSet.Empty[RequestInput[A]]())
+      .:+:(Header.schemaCase[A])
+      .:+:(Query.schemaCase[A])
+      .:+:(Path.schemaCase[A])
+      .:+:(Body.schemaCase[A])
+  )
+
   private[http] final case class ZipWith[A, B, C](
-      left: RequestInput[A],
-      right: RequestInput[B],
-      g: C => (A, B)
-  ) extends RequestInput[C]
+    left: RequestInput[A],
+    right: RequestInput[B],
+    zipper: Zipper.WithOut[A, B, C]
+  ) extends RequestInput[C] {
+    override def schema: Schema[C] =
+      left.schema
+        .zip(right.schema)
+        .transform(
+          (zipper.zip _).tupled,
+          zipper.unzip
+        )
+  }
+
+  object ZipWith {
+
+    def schema[A, B, C] =
+      Schema.CaseClass3[RequestInput[A], RequestInput[B], Zipper.WithOut[A, B, C], ZipWith[A, B, C]](
+        Schema.Field("left", RequestInput.schema[A]),
+        Schema.Field("right", RequestInput.schema[B]),
+        Schema.Field("zipper", Zipper.schema[A, B, C]),
+        ZipWith(_, _, _),
+        _.left,
+        _.right,
+        _.zipper
+      )
+
+    def schemaCase[A]: Schema.Case[ZipWith[Any, Any, Any], RequestInput[A]] =
+      Schema.Case("ZipWith", schema[Any, Any, Any], _.asInstanceOf[ZipWith[Any, Any, Any]])
+  }
+
 }
 
-/** =HEADERS=
-  */
+/**
+ * =HEADERS=
+ */
 sealed trait Header[A] extends RequestInput[A] {
   self =>
 
   def ? : Header[Option[A]] =
     Header.Optional(self)
 
-  def ++[B](that: Header[B])(implicit unzipper: Unzippable[A, B]): Header[unzipper.In] =
-    Header.ZipWith[A, B, unzipper.In](self, that, unzipper.unzip)
+  def ++[B](that: Header[B])(implicit zipper: Zipper[A, B]): Header[zipper.Out] =
+    Header.ZipWith[A, B, zipper.Out](self, that, zipper)
 }
 
 object Header {
@@ -44,52 +83,194 @@ object Header {
   def Host: Header[String]           = string("Host")
   def Accept: Header[String]         = string("Accept")
 
-  def string(name: String): Header[String] = SingleHeader(name)
+  def string(name: String): Header[String] = SingleHeader(name, Schema[String])
 
-  private[http] final case class SingleHeader[A](name: String) extends Header[A] 
+  def schema[A]: Schema[Header[A]] = Schema.EnumN(
+    CaseSet
+      .Cons(SingleHeader.schemaCase[A], CaseSet.Empty[Header[A]]())
+      .:+:(ZipWith.schemaCase[A])
+      .:+:(Optional.schemaCase[A])
+  )
 
-  private[http] final case class ZipWith[A, B, C](left: Header[A], right: Header[B], g: C => (A, B))
-      extends Header[C]
+  def schemaCase[A]: Schema.Case[Header[A], RequestInput[A]] =
+    Schema.Case("Header", schema[A], _.asInstanceOf[Header[A]])
 
-  private[http] case class Optional[A](headers: Header[A]) extends Header[Option[A]]
+  private[http] final case class SingleHeader[A](name: String, override val schema: Schema[A]) extends Header[A]
+  object SingleHeader {
+
+    def schema[A]: Schema[SingleHeader[A]] = Schema.CaseClass2[String, FlowSchemaAst, SingleHeader[A]](
+      Schema.Field("name", Schema[String]),
+      Schema.Field("schema", FlowSchemaAst.schema),
+      (name, schema) => SingleHeader(name, schema.toSchema[A]),
+      _.name,
+      header => FlowSchemaAst.fromSchema(header.schema)
+    )
+
+    def schemaCase[A]: Schema.Case[SingleHeader[A], Header[A]] =
+      Schema.Case("SingleHeader", schema[A], _.asInstanceOf[SingleHeader[A]])
+  }
+
+  private[http] final case class ZipWith[A, B, C](left: Header[A], right: Header[B], zipper: Zipper.WithOut[A, B, C])
+      extends Header[C] {
+
+    def schema: Schema[C] =
+      left.schema
+        .zip(right.schema)
+        .transform(
+          (zipper.zip _).tupled,
+          zipper.unzip
+        )
+  }
+
+  object ZipWith {
+
+    def schema[A, B, C] =
+      Schema.CaseClass3[Header[A], Header[B], Zipper.WithOut[A, B, C], ZipWith[A, B, C]](
+        Schema.Field("left", Header.schema[A]),
+        Schema.Field("right", Header.schema[B]),
+        Schema.Field("zipper", Zipper.schema[A, B, C]),
+        ZipWith(_, _, _),
+        _.left,
+        _.right,
+        _.zipper
+      )
+
+    def schemaCase[A]: Schema.Case[ZipWith[Any, Any, Any], Header[A]] =
+      Schema.Case("ZipWith", schema[Any, Any, Any], _.asInstanceOf[ZipWith[Any, Any, Any]])
+
+  }
+
+  private[http] case class Optional[A](headers: Header[A]) extends Header[Option[A]] {
+    def schema: Schema[Option[A]] = Schema.option(headers.schema)
+  }
+
+  object Optional {
+
+    def schema[A]: Schema[Optional[A]] = Schema.CaseClass1(
+      Schema.Field("headers", Header.schema[A]),
+      Optional.apply,
+      _.headers
+    )
+
+    def schemaCase[A]: Schema.Case[Optional[A], Header[A]] =
+      Schema.Case("Optional", schema[A], _.asInstanceOf[Optional[A]])
+  }
 }
 
-case class Body[A](codec: JsonCodec[A], schema: Schema[A]) extends RequestInput[A] { self =>
+case class Body[A](override val schema: Schema[A]) extends RequestInput[A] { self =>
   def ++[B](that: Body[B]): Body[B] = that
 }
 
-/** QUERY PARAMS
-  * ============
-  */
+object Body {
+
+  def schema[A]: Schema[Body[A]] = Schema.CaseClass1[FlowSchemaAst, Body[A]](
+    Schema.Field("schema", FlowSchemaAst.schema),
+    a => Body(a.toSchema[A]),
+    s => FlowSchemaAst.fromSchema(s.schema)
+  )
+
+  def schemaCase[A]: Schema.Case[Body[A], RequestInput[A]] =
+    Schema.Case("Body", schema[A], _.asInstanceOf[Body[A]])
+}
+
+/**
+ * QUERY PARAMS
+ * ============
+ */
 sealed trait Query[A] extends RequestInput[A] { self =>
   def ? : Query[Option[A]] = Query.Optional(self)
 
-  def ++[B](that: Query[B])(unzipper: Unzippable[A, B]): Query[unzipper.In] =
-    Query.ZipWith[A, B, unzipper.In](self, that, unzipper.unzip)
+  def ++[B](that: Query[B])(zipper: Zipper[A, B]): Query[zipper.Out] =
+    Query.ZipWith[A, B, zipper.Out](self, that, zipper)
 }
 
 object Query {
 
-  private[http] final case class SingleParam[A](name: String, schema: Schema[A]) extends Query[A]
+  def schema[A]: Schema[Query[A]] = Schema.EnumN(
+    CaseSet
+      .Cons(SingleParam.schemaCase[A], CaseSet.Empty[Query[A]]())
+      .:+:(ZipWith.schemaCase[A])
+      .:+:(Optional.schemaCase[A])
+  )
 
-  private[http] final case class ZipWith[A, B, C](left: Query[A], right: Query[B], g: C => (A, B))
-      extends Query[C]
+  def schemaCase[A]: Schema.Case[Query[A], RequestInput[A]] =
+    Schema.Case("Query", schema[A], _.asInstanceOf[Query[A]])
 
-  private[http] case class Optional[A](params: Query[A]) extends Query[Option[A]]
+  private[http] final case class SingleParam[A](name: String, override val schema: Schema[A]) extends Query[A]
+
+  object SingleParam {
+
+    def schema[A]: Schema[SingleParam[A]] = Schema.CaseClass2[String, FlowSchemaAst, SingleParam[A]](
+      Schema.Field("name", Schema[String]),
+      Schema.Field("schema", FlowSchemaAst.schema),
+      (name, schema) => SingleParam(name, schema.toSchema[A]),
+      _.name,
+      param => FlowSchemaAst.fromSchema(param.schema)
+    )
+
+    def schemaCase[A]: Schema.Case[SingleParam[A], Query[A]] =
+      Schema.Case("SingleParam", schema[A], _.asInstanceOf[SingleParam[A]])
+
+  }
+
+  private[http] final case class ZipWith[A, B, C](left: Query[A], right: Query[B], zipper: Zipper.WithOut[A, B, C])
+      extends Query[C] {
+    val schema: Schema[C] =
+      left.schema
+        .zip(right.schema)
+        .transform(
+          (zipper.zip _).tupled,
+          zipper.unzip
+        )
+  }
+
+  object ZipWith {
+
+    def schema[A, B, C] =
+      Schema.CaseClass3[Query[A], Query[B], Zipper.WithOut[A, B, C], ZipWith[A, B, C]](
+        Schema.Field("left", Query.schema[A]),
+        Schema.Field("right", Query.schema[B]),
+        Schema.Field("zipper", Zipper.schema[A, B, C]),
+        ZipWith(_, _, _),
+        _.left,
+        _.right,
+        _.zipper
+      )
+
+    def schemaCase[A]: Schema.Case[ZipWith[Any, Any, Any], Query[A]] =
+      Schema.Case("ZipWith", schema[Any, Any, Any], _.asInstanceOf[ZipWith[Any, Any, Any]])
+
+  }
+
+  private[http] case class Optional[A](params: Query[A]) extends Query[Option[A]] {
+    def schema: Schema[Option[A]] = Schema.option(params.schema)
+  }
+
+  object Optional {
+    def schema[A]: Schema[Optional[A]] = Schema.CaseClass1(
+      Schema.Field("params", Query.schema[A]),
+      Optional.apply,
+      _.params
+    )
+
+    def schemaCase[A]: Schema.Case[Optional[A], Query[A]] =
+      Schema.Case("Optional", schema[A], _.asInstanceOf[Optional[A]])
+  }
 }
 
-/** A DSL for describe Paths
-  *   - ex: /users
-  *   - ex: /users/:id/friends
-  *   - ex: /users/:id/friends/:friendId
-  *   - ex: /posts/:id/comments/:commentId
-  */
+/**
+ * A DSL for describe Paths
+ *   - ex: /users
+ *   - ex: /users/:id/friends
+ *   - ex: /users/:id/friends/:friendId
+ *   - ex: /posts/:id/comments/:commentId
+ */
 sealed trait Path[A] extends RequestInput[A] { self =>
-  def /[B](that: Path[B])(implicit unzipper: Unzippable[A, B]): Path[unzipper.In] =
-    Path.ZipWith[A, B, unzipper.In](this, that, unzipper.unzip)
+  def /[B](that: Path[B])(implicit zipper: Zipper[A, B]): Path[zipper.Out] =
+    Path.ZipWith[A, B, zipper.Out](this, that, zipper)
 
   def /(string: String): Path[A] =
-    Path.ZipWith(this, Path.path(string), a => (a, ()))
+    Path.ZipWith(this, Path.path(string), Zipper.zipperRightIdentity)
 }
 
 final case class PathState(var input: List[String])
@@ -97,10 +278,65 @@ final case class PathState(var input: List[String])
 object Path {
   def path(name: String): Path[Unit] = Path.Literal(name).asInstanceOf[Path[Unit]]
 
-  private[http] final case class Literal(string: String) extends Path[Any]
+  def schema[A]: Schema[Path[A]] = Schema.EnumN(
+    CaseSet
+      .Cons(Literal.schemaCase[A], CaseSet.Empty[Path[A]]())
+      .:+:(Match.schemaCase[A])
+      .:+:(ZipWith.schemaCase[A])
+  )
+
+  def schemaCase[A]: Schema.Case[Path[A], RequestInput[A]] =
+    Schema.Case("Path", schema[A], _.asInstanceOf[Path[A]])
+
+  private[http] final case class Literal(string: String) extends Path[Any] {
+    def schema: Schema[Any] = Schema.singleton(())
+  }
+
+  object Literal {
+    def schema: Schema[Literal] = DeriveSchema.gen[Literal]
+
+    def schemaCase[A]: Schema.Case[Literal, Path[A]] =
+      Schema.Case("Literal", schema, _.asInstanceOf[Literal])
+  }
 
   private[http] final case class Match[A](name: String, schema: Schema[A]) extends Path[A]
 
-  private[http] final case class ZipWith[A, B, C](left: Path[A], right: Path[B], g: C => (A, B))
-      extends Path[C]
+  object Match {
+    def schema[A]: Schema[Match[A]] = Schema.CaseClass2[String, FlowSchemaAst, Match[A]](
+      Schema.Field("name", Schema[String]),
+      Schema.Field("schema", FlowSchemaAst.schema),
+      (name, schema) => Match(name, schema.toSchema[A]),
+      _.name,
+      m => FlowSchemaAst.fromSchema(m.schema)
+    )
+
+    def schemaCase[A]: Schema.Case[Match[A], Path[A]] =
+      Schema.Case("Match", schema[A], _.asInstanceOf[Match[A]])
+  }
+
+  private[http] final case class ZipWith[A, B, C](left: Path[A], right: Path[B], zipper: Zipper.WithOut[A, B, C])
+      extends Path[C] {
+    def schema: Schema[C] = left.schema
+      .zip(right.schema)
+      .transform(
+        (zipper.zip _).tupled,
+        zipper.unzip
+      )
+  }
+
+  object ZipWith {
+    def schema[A, B, C]: Schema[ZipWith[A, B, C]] =
+      Schema.CaseClass3[Path[A], Path[B], Zipper.WithOut[A, B, C], ZipWith[A, B, C]](
+        Schema.Field("left", Path.schema[A]),
+        Schema.Field("right", Path.schema[B]),
+        Schema.Field("zipper", Zipper.schema[A, B, C]),
+        ZipWith(_, _, _),
+        _.left,
+        _.right,
+        _.zipper
+      )
+
+    def schemaCase[A]: Schema.Case[ZipWith[Any, Any, Any], Path[A]] =
+      Schema.Case("ZipWith", schema[Any, Any, Any], _.asInstanceOf[ZipWith[Any, Any, Any]])
+  }
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/Path.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/Path.scala
@@ -36,13 +36,7 @@ object RequestInput {
     right: RequestInput[B],
     zipper: Zipper.WithOut[A, B, C]
   ) extends RequestInput[C] {
-    lazy val schema: Schema[C] =
-      left.schema
-        .zip(right.schema)
-        .transform(
-          (zipper.zip _).tupled,
-          zipper.unzip
-        )
+    lazy val schema: Schema[C] = zipper.zipSchema(left.schema, right.schema)
   }
 
   object ZipWith {
@@ -113,13 +107,7 @@ object Header {
   private[http] final case class ZipWith[A, B, C](left: Header[A], right: Header[B], zipper: Zipper.WithOut[A, B, C])
       extends Header[C] {
 
-    lazy val schema: Schema[C] =
-      left.schema
-        .zip(right.schema)
-        .transform(
-          (zipper.zip _).tupled,
-          zipper.unzip
-        )
+    lazy val schema: Schema[C] = zipper.zipSchema(left.schema, right.schema)
   }
 
   object ZipWith {
@@ -215,13 +203,7 @@ object Query {
 
   private[http] final case class ZipWith[A, B, C](left: Query[A], right: Query[B], zipper: Zipper.WithOut[A, B, C])
       extends Query[C] {
-    val schema: Schema[C] =
-      left.schema
-        .zip(right.schema)
-        .transform(
-          (zipper.zip _).tupled,
-          zipper.unzip
-        )
+    val schema: Schema[C] = zipper.zipSchema(left.schema, right.schema)
   }
 
   object ZipWith {
@@ -288,8 +270,8 @@ object Path {
   def schemaCase[A]: Schema.Case[Path[A], RequestInput[A]] =
     Schema.Case("Path", schema[A], _.asInstanceOf[Path[A]])
 
-  private[http] final case class Literal(string: String) extends Path[Any] {
-    lazy val schema: Schema[Any] = Schema.singleton(())
+  private[http] final case class Literal(string: String) extends Path[Unit] {
+    lazy val schema: Schema[Unit] = Schema.singleton(())
   }
 
   object Literal {
@@ -316,12 +298,7 @@ object Path {
 
   private[http] final case class ZipWith[A, B, C](left: Path[A], right: Path[B], zipper: Zipper.WithOut[A, B, C])
       extends Path[C] {
-    lazy val schema: Schema[C] = left.schema
-      .zip(right.schema)
-      .transform(
-        (zipper.zip _).tupled,
-        zipper.unzip
-      )
+    lazy val schema: Schema[C] = zipper.zipSchema(left.schema, right.schema)
   }
 
   object ZipWith {

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/Path.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/Path.scala
@@ -162,8 +162,7 @@ object Body {
 }
 
 /**
- * QUERY PARAMS
- * ============
+ * =QUERY PARAMS=
  */
 sealed trait Query[A] extends RequestInput[A] { self =>
   def ? : Query[Option[A]] = Query.Optional(self)

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/Path.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/Path.scala
@@ -1,0 +1,106 @@
+package zio.flow.operation.http
+
+import zhttp.http.{Request, Header => ZHeader}
+import zio.schema.Schema
+
+import scala.language.implicitConversions
+import zio.Zippable
+import zio.Unzippable
+import zio.json.JsonCodec
+
+/** A RequestInput is a description of a Path, Query Parameters, and Headers and Body
+  *   - Path: /users/:id/posts
+  *   - Query Parameters: ?page=1&limit=10
+  *   - Headers: X-User-Id: 1 or Accept: application/json
+  */
+sealed trait RequestInput[A] extends Product with Serializable { self =>
+  private[http] def ++[B](that: RequestInput[B])(implicit unzipper: Unzippable[A, B]): RequestInput[unzipper.In] =
+    RequestInput.ZipWith[A, B, unzipper.In](self, that, unzipper.unzip)
+}
+
+object RequestInput {
+  private[http] final case class ZipWith[A, B, C](
+      left: RequestInput[A],
+      right: RequestInput[B],
+      g: C => (A, B)
+  ) extends RequestInput[C]
+}
+
+/** =HEADERS=
+  */
+sealed trait Header[A] extends RequestInput[A] {
+  self =>
+
+  def ? : Header[Option[A]] =
+    Header.Optional(self)
+
+  def ++[B](that: Header[B])(implicit unzipper: Unzippable[A, B]): Header[unzipper.In] =
+    Header.ZipWith[A, B, unzipper.In](self, that, unzipper.unzip)
+}
+
+object Header {
+  def AcceptEncoding: Header[String] = string("Accept-Encoding")
+  def UserAgent: Header[String]      = string("User-Agent")
+  def Host: Header[String]           = string("Host")
+  def Accept: Header[String]         = string("Accept")
+
+  def string(name: String): Header[String] = SingleHeader(name)
+
+  private[http] final case class SingleHeader[A](name: String) extends Header[A] 
+
+  private[http] final case class ZipWith[A, B, C](left: Header[A], right: Header[B], g: C => (A, B))
+      extends Header[C]
+
+  private[http] case class Optional[A](headers: Header[A]) extends Header[Option[A]]
+}
+
+case class Body[A](codec: JsonCodec[A], schema: Schema[A]) extends RequestInput[A] { self =>
+  def ++[B](that: Body[B]): Body[B] = that
+}
+
+/** QUERY PARAMS
+  * ============
+  */
+sealed trait Query[A] extends RequestInput[A] { self =>
+  def ? : Query[Option[A]] = Query.Optional(self)
+
+  def ++[B](that: Query[B])(unzipper: Unzippable[A, B]): Query[unzipper.In] =
+    Query.ZipWith[A, B, unzipper.In](self, that, unzipper.unzip)
+}
+
+object Query {
+
+  private[http] final case class SingleParam[A](name: String, schema: Schema[A]) extends Query[A]
+
+  private[http] final case class ZipWith[A, B, C](left: Query[A], right: Query[B], g: C => (A, B))
+      extends Query[C]
+
+  private[http] case class Optional[A](params: Query[A]) extends Query[Option[A]]
+}
+
+/** A DSL for describe Paths
+  *   - ex: /users
+  *   - ex: /users/:id/friends
+  *   - ex: /users/:id/friends/:friendId
+  *   - ex: /posts/:id/comments/:commentId
+  */
+sealed trait Path[A] extends RequestInput[A] { self =>
+  def /[B](that: Path[B])(implicit unzipper: Unzippable[A, B]): Path[unzipper.In] =
+    Path.ZipWith[A, B, unzipper.In](this, that, unzipper.unzip)
+
+  def /(string: String): Path[A] =
+    Path.ZipWith(this, Path.path(string), a => (a, ()))
+}
+
+final case class PathState(var input: List[String])
+
+object Path {
+  def path(name: String): Path[Unit] = Path.Literal(name).asInstanceOf[Path[Unit]]
+
+  private[http] final case class Literal(string: String) extends Path[Any]
+
+  private[http] final case class Match[A](name: String, schema: Schema[A]) extends Path[A]
+
+  private[http] final case class ZipWith[A, B, C](left: Path[A], right: Path[B], g: C => (A, B))
+      extends Path[C]
+}

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/Zipper.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/Zipper.scala
@@ -16,6 +16,7 @@ object Zipper extends ZipperLowPriority1 {
       CaseSet
         .Cons(zipperLeftIdentitySchemaCase[A, B, C], CaseSet.Empty[Zipper.WithOut[A, B, C]]())
         .:+:(zipperRightIdentitySchemaCase[A, B, C])
+        .:+:(zipper2SchemaCase[A, B, C])
         .:+:(zipper3SchemaCase[A, B, C])
         .:+:(zipper4SchemaCase[A, B, C])
         .:+:(zipper5SchemaCase[A, B, C])
@@ -23,10 +24,9 @@ object Zipper extends ZipperLowPriority1 {
 
   type WithOut[A, B, C] = Zipper[A, B] { type Out = C }
 
-  implicit def zipperLeftIdentity[A]: Zipper.WithOut[Unit, A, A] =
-    new ZipperLeftIdentity[A]
+  implicit def zipperLeftIdentity[A]: Zipper.WithOut[Unit, A, A] = ZipperLeftIdentity[A]()
 
-  class ZipperLeftIdentity[A] extends Zipper[Unit, A] {
+  case class ZipperLeftIdentity[A]() extends Zipper[Unit, A] {
     type Out = A
     def zip(left: Unit, right: A): A =
       right
@@ -36,31 +36,33 @@ object Zipper extends ZipperLowPriority1 {
   }
 
   def zipperLeftIdentitySchemaCase[A, B, C]: Schema.Case[ZipperLeftIdentity[Any], Zipper.WithOut[A, B, C]] =
-    Schema.Case("leftIdentity", Schema.singleton(new ZipperLeftIdentity[Any]), _.asInstanceOf[ZipperLeftIdentity[Any]])
+    Schema.Case("leftIdentity", Schema.singleton(ZipperLeftIdentity[Any]()), _.asInstanceOf[ZipperLeftIdentity[Any]])
 
   def zipperRightIdentitySchemaCase[A, B, C]: Schema.Case[ZipperRightIdentity[Any], Zipper.WithOut[A, B, C]] =
-    Schema.Case("rightIdentity", Schema.singleton(new ZipperRightIdentity[Any]), _.asInstanceOf[ZipperRightIdentity[Any]])
+    Schema.Case("rightIdentity", Schema.singleton(ZipperRightIdentity[Any]()), _.asInstanceOf[ZipperRightIdentity[Any]])
+
+  def zipper2SchemaCase[A, B, C]: Schema.Case[Zipper2[Any, Any], Zipper.WithOut[A, B, C]] =
+    Schema.Case("2", Schema.singleton(Zipper2[Any, Any]()), _.asInstanceOf[Zipper2[Any, Any]])
 
   def zipper3SchemaCase[A, B, C]: Schema.Case[Zipper3[Any, Any, Any], Zipper.WithOut[A, B, C]] =
-    Schema.Case("3", Schema.singleton(new Zipper3[Any, Any, Any]), _.asInstanceOf[Zipper3[Any, Any, Any]])
+    Schema.Case("3", Schema.singleton(Zipper3[Any, Any, Any]()), _.asInstanceOf[Zipper3[Any, Any, Any]])
 
   def zipper4SchemaCase[A, B, C]: Schema.Case[Zipper4[Any, Any, Any, Any], Zipper.WithOut[A, B, C]] =
-    Schema.Case("4", Schema.singleton(new Zipper4[Any, Any, Any, Any]), _.asInstanceOf[Zipper4[Any, Any, Any, Any]])
+    Schema.Case("4", Schema.singleton(Zipper4[Any, Any, Any, Any]()), _.asInstanceOf[Zipper4[Any, Any, Any, Any]])
 
   def zipper5SchemaCase[A, B, C]: Schema.Case[Zipper5[Any, Any, Any, Any, Any], Zipper.WithOut[A, B, C]] =
     Schema.Case(
       "5",
-      Schema.singleton(new Zipper5[Any, Any, Any, Any, Any]),
+      Schema.singleton(Zipper5[Any, Any, Any, Any, Any]()),
       _.asInstanceOf[Zipper5[Any, Any, Any, Any, Any]]
     )
 }
 
 trait ZipperLowPriority1 extends ZipperLowPriority2 {
 
-  implicit def zipperRightIdentity[A]: Zipper.WithOut[A, Unit, A] =
-    new ZipperRightIdentity[A]
+  implicit def zipperRightIdentity[A]: Zipper.WithOut[A, Unit, A] = ZipperRightIdentity[A]()
 
-  class ZipperRightIdentity[A] extends Zipper[A, Unit] {
+  case class ZipperRightIdentity[A]() extends Zipper[A, Unit] {
     type Out = A
     def zip(left: A, right: Unit): A =
       left
@@ -75,7 +77,7 @@ trait ZipperLowPriority2 extends ZipperLowPriority3 {
   implicit def zipper3[A, B, Z]: Zipper.WithOut[(A, B), Z, (A, B, Z)] =
     new Zipper3[A, B, Z]
 
-  class Zipper3[A, B, Z] extends Zipper[(A, B), Z] {
+  case class Zipper3[A, B, Z]() extends Zipper[(A, B), Z] {
     type Out = (A, B, Z)
     def zip(left: (A, B), right: Z): (A, B, Z) =
       (left._1, left._2, right)
@@ -84,10 +86,9 @@ trait ZipperLowPriority2 extends ZipperLowPriority3 {
       ((out._1, out._2), out._3)
   }
 
-  implicit def zipper4[A, B, C, Z]: Zipper.WithOut[(A, B, C), Z, (A, B, C, Z)] =
-    new Zipper4[A, B, C, Z]
+  implicit def zipper4[A, B, C, Z]: Zipper.WithOut[(A, B, C), Z, (A, B, C, Z)] = Zipper4[A, B, C, Z]()
 
-  class Zipper4[A, B, C, Z] extends Zipper[(A, B, C), Z] {
+  case class Zipper4[A, B, C, Z]() extends Zipper[(A, B, C), Z] {
     type Out = (A, B, C, Z)
     def zip(left: (A, B, C), right: Z): (A, B, C, Z) =
       (left._1, left._2, left._3, right)
@@ -96,10 +97,9 @@ trait ZipperLowPriority2 extends ZipperLowPriority3 {
       ((out._1, out._2, out._3), out._4)
   }
 
-  implicit def zipper5[A, B, C, D, Z]: Zipper.WithOut[(A, B, C, D), Z, (A, B, C, D, Z)] =
-    new Zipper5[A, B, C, D, Z]
+  implicit def zipper5[A, B, C, D, Z]: Zipper.WithOut[(A, B, C, D), Z, (A, B, C, D, Z)] = Zipper5[A, B, C, D, Z]()
 
-  class Zipper5[A, B, C, D, Z] extends Zipper[(A, B, C, D), Z] {
+  case class Zipper5[A, B, C, D, Z]() extends Zipper[(A, B, C, D), Z] {
     type Out = (A, B, C, D, Z)
     def zip(left: (A, B, C, D), right: Z): (A, B, C, D, Z) =
       (left._1, left._2, left._3, left._4, right)
@@ -487,12 +487,14 @@ trait ZipperLowPriority2 extends ZipperLowPriority3 {
 
 trait ZipperLowPriority3 {
 
-  implicit def Zipper2[A, B]: Zipper.WithOut[A, B, (A, B)] =
-    new Zipper[A, B] {
-      type Out = (A, B)
-      def zip(left: A, right: B): Out = (left, right)
+  implicit def zipper2[A, B]: Zipper.WithOut[A, B, (A, B)] =
+    new Zipper2[A, B]
 
-      override def unzip(out: (A, B)): (A, B) =
-        out
-    }
+  case class Zipper2[A, B]() extends Zipper[A, B] {
+    type Out = (A, B)
+    def zip(left: A, right: B): Out = (left, right)
+
+    override def unzip(out: (A, B)): (A, B) =
+      out
+  }
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/Zipper.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/Zipper.scala
@@ -36,7 +36,7 @@ object Zipper extends ZipperLowPriority1 {
     override def unzip(out: A): (Unit, A) =
       ((), out)
 
-    override def zipSchema(left: Schema[Unit], right: Schema[A]): Schema[A] = 
+    override def zipSchema(left: Schema[Unit], right: Schema[A]): Schema[A] =
       right
   }
 
@@ -91,8 +91,8 @@ trait ZipperLowPriority2 extends ZipperLowPriority3 {
 
     override def unzip(out: (A, B, Z)): ((A, B), Z) =
       ((out._1, out._2), out._3)
-    
-    override def zipSchema(left: Schema[(A, B)], right: Schema[Z]): Schema[(A, B, Z)] = 
+
+    override def zipSchema(left: Schema[(A, B)], right: Schema[Z]): Schema[(A, B, Z)] =
       left.zip(right).transform((zip _).tupled, unzip)
   }
 
@@ -106,7 +106,7 @@ trait ZipperLowPriority2 extends ZipperLowPriority3 {
     override def unzip(out: (A, B, C, Z)): ((A, B, C), Z) =
       ((out._1, out._2, out._3), out._4)
 
-    override def zipSchema(left: Schema[(A, B, C)], right: Schema[Z]): Schema[(A, B, C, Z)] = 
+    override def zipSchema(left: Schema[(A, B, C)], right: Schema[Z]): Schema[(A, B, C, Z)] =
       left.zip(right).transform((zip _).tupled, unzip)
   }
 
@@ -119,8 +119,8 @@ trait ZipperLowPriority2 extends ZipperLowPriority3 {
 
     override def unzip(out: (A, B, C, D, Z)): ((A, B, C, D), Z) =
       ((out._1, out._2, out._3, out._4), out._5)
-    
-    override def zipSchema(left: Schema[(A, B, C, D)], right: Schema[Z]): Schema[(A, B, C, D, Z)] = 
+
+    override def zipSchema(left: Schema[(A, B, C, D)], right: Schema[Z]): Schema[(A, B, C, D, Z)] =
       left.zip(right).transform((zip _).tupled, unzip)
   }
 
@@ -513,7 +513,7 @@ trait ZipperLowPriority3 {
     override def unzip(out: (A, B)): (A, B) =
       out
 
-    override def zipSchema(left: Schema[A], right: Schema[B]): Schema[(A, B)] = 
+    override def zipSchema(left: Schema[A], right: Schema[B]): Schema[(A, B)] =
       left.zip(right).transform((zip _).tupled, unzip)
   }
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/Zipper.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/Zipper.scala
@@ -1,0 +1,498 @@
+package zio.flow.operation.http
+
+import zio.schema.Schema
+import zio.schema.CaseSet
+
+trait Zipper[A, B] {
+  type Out
+  def zip(left: A, right: B): Out
+  def unzip(out: Out): (A, B)
+}
+
+object Zipper extends ZipperLowPriority1 {
+
+  implicit def schema[A, B, C]: Schema[Zipper.WithOut[A, B, C]] =
+    Schema.EnumN(
+      CaseSet
+        .Cons(zipperLeftIdentitySchemaCase[A, B, C], CaseSet.Empty[Zipper.WithOut[A, B, C]]())
+        .:+:(zipperRightIdentitySchemaCase[A, B, C])
+        .:+:(zipper3SchemaCase[A, B, C])
+        .:+:(zipper4SchemaCase[A, B, C])
+        .:+:(zipper5SchemaCase[A, B, C])
+    )
+
+  type WithOut[A, B, C] = Zipper[A, B] { type Out = C }
+
+  implicit def zipperLeftIdentity[A]: Zipper.WithOut[Unit, A, A] =
+    new ZipperLeftIdentity[A]
+
+  class ZipperLeftIdentity[A] extends Zipper[Unit, A] {
+    type Out = A
+    def zip(left: Unit, right: A): A =
+      right
+
+    override def unzip(out: A): (Unit, A) =
+      ((), out)
+  }
+
+  def zipperLeftIdentitySchemaCase[A, B, C]: Schema.Case[ZipperLeftIdentity[Any], Zipper.WithOut[A, B, C]] =
+    Schema.Case("leftIdentity", Schema.singleton(new ZipperLeftIdentity[Any]), _.asInstanceOf[ZipperLeftIdentity[Any]])
+
+  def zipperRightIdentitySchemaCase[A, B, C]: Schema.Case[ZipperRightIdentity[Any], Zipper.WithOut[A, B, C]] =
+    Schema.Case("rightIdentity", Schema.singleton(new ZipperRightIdentity[Any]), _.asInstanceOf[ZipperRightIdentity[Any]])
+
+  def zipper3SchemaCase[A, B, C]: Schema.Case[Zipper3[Any, Any, Any], Zipper.WithOut[A, B, C]] =
+    Schema.Case("3", Schema.singleton(new Zipper3[Any, Any, Any]), _.asInstanceOf[Zipper3[Any, Any, Any]])
+
+  def zipper4SchemaCase[A, B, C]: Schema.Case[Zipper4[Any, Any, Any, Any], Zipper.WithOut[A, B, C]] =
+    Schema.Case("4", Schema.singleton(new Zipper4[Any, Any, Any, Any]), _.asInstanceOf[Zipper4[Any, Any, Any, Any]])
+
+  def zipper5SchemaCase[A, B, C]: Schema.Case[Zipper5[Any, Any, Any, Any, Any], Zipper.WithOut[A, B, C]] =
+    Schema.Case(
+      "5",
+      Schema.singleton(new Zipper5[Any, Any, Any, Any, Any]),
+      _.asInstanceOf[Zipper5[Any, Any, Any, Any, Any]]
+    )
+}
+
+trait ZipperLowPriority1 extends ZipperLowPriority2 {
+
+  implicit def zipperRightIdentity[A]: Zipper.WithOut[A, Unit, A] =
+    new ZipperRightIdentity[A]
+
+  class ZipperRightIdentity[A] extends Zipper[A, Unit] {
+    type Out = A
+    def zip(left: A, right: Unit): A =
+      left
+
+    override def unzip(out: A): (A, Unit) =
+      (out, ())
+  }
+}
+
+trait ZipperLowPriority2 extends ZipperLowPriority3 {
+
+  implicit def zipper3[A, B, Z]: Zipper.WithOut[(A, B), Z, (A, B, Z)] =
+    new Zipper3[A, B, Z]
+
+  class Zipper3[A, B, Z] extends Zipper[(A, B), Z] {
+    type Out = (A, B, Z)
+    def zip(left: (A, B), right: Z): (A, B, Z) =
+      (left._1, left._2, right)
+
+    override def unzip(out: (A, B, Z)): ((A, B), Z) =
+      ((out._1, out._2), out._3)
+  }
+
+  implicit def zipper4[A, B, C, Z]: Zipper.WithOut[(A, B, C), Z, (A, B, C, Z)] =
+    new Zipper4[A, B, C, Z]
+
+  class Zipper4[A, B, C, Z] extends Zipper[(A, B, C), Z] {
+    type Out = (A, B, C, Z)
+    def zip(left: (A, B, C), right: Z): (A, B, C, Z) =
+      (left._1, left._2, left._3, right)
+
+    override def unzip(out: (A, B, C, Z)): ((A, B, C), Z) =
+      ((out._1, out._2, out._3), out._4)
+  }
+
+  implicit def zipper5[A, B, C, D, Z]: Zipper.WithOut[(A, B, C, D), Z, (A, B, C, D, Z)] =
+    new Zipper5[A, B, C, D, Z]
+
+  class Zipper5[A, B, C, D, Z] extends Zipper[(A, B, C, D), Z] {
+    type Out = (A, B, C, D, Z)
+    def zip(left: (A, B, C, D), right: Z): (A, B, C, D, Z) =
+      (left._1, left._2, left._3, left._4, right)
+
+    override def unzip(out: (A, B, C, D, Z)): ((A, B, C, D), Z) =
+      ((out._1, out._2, out._3, out._4), out._5)
+  }
+
+  // implicit def Zipper6[A, B, C, D, E, Z]: Zipper.WithOut[(A, B, C, D, E), Z, (A, B, C, D, E, Z)] =
+  //   new Zipper[(A, B, C, D, E), Z] {
+  //     type Out = (A, B, C, D, E, Z)
+  //     def zip(left: (A, B, C, D, E), right: Z): (A, B, C, D, E, Z) =
+  //       (left._1, left._2, left._3, left._4, left._5, right)
+
+  //     override def unzip(out: (A, B, C, D, E, Z)): ((A, B, C, D, E), Z) =
+  //       ((out._1, out._2, out._3, out._4, out._5), out._6)
+  //   }
+
+  // implicit def Zipper7[A, B, C, D, E, F, Z]: Zipper.WithOut[(A, B, C, D, E, F), Z, (A, B, C, D, E, F, Z)] =
+  //   new Zipper[(A, B, C, D, E, F), Z] {
+  //     type Out = (A, B, C, D, E, F, Z)
+  //     def zip(left: (A, B, C, D, E, F), right: Z): (A, B, C, D, E, F, Z) =
+  //       (left._1, left._2, left._3, left._4, left._5, left._6, right)
+
+  //     override def unzip(out: (A, B, C, D, E, F, Z)): ((A, B, C, D, E, F), Z) =
+  //       ((out._1, out._2, out._3, out._4, out._5, out._6), out._7)
+  //   }
+
+  // implicit def Zipper8[A, B, C, D, E, F, G, Z]: Zipper.WithOut[(A, B, C, D, E, F, G), Z, (A, B, C, D, E, F, G, Z)] =
+  //   new Zipper[(A, B, C, D, E, F, G), Z] {
+  //     type Out = (A, B, C, D, E, F, G, Z)
+  //     def zip(left: (A, B, C, D, E, F, G), right: Z): (A, B, C, D, E, F, G, Z) =
+  //       (left._1, left._2, left._3, left._4, left._5, left._6, left._7, right)
+
+  //     override def unzip(out: (A, B, C, D, E, F, G, Z)): ((A, B, C, D, E, F, G), Z) =
+  //       ((out._1, out._2, out._3, out._4, out._5, out._6, out._7), out._8)
+  //   }
+
+  // implicit def Zipper9[A, B, C, D, E, F, G, H, Z]
+  //     : Zipper.WithOut[(A, B, C, D, E, F, G, H), Z, (A, B, C, D, E, F, G, H, Z)] =
+  //   new Zipper[(A, B, C, D, E, F, G, H), Z] {
+  //     type Out = (A, B, C, D, E, F, G, H, Z)
+  //     def zip(left: (A, B, C, D, E, F, G, H), right: Z): (A, B, C, D, E, F, G, H, Z) =
+  //       (left._1, left._2, left._3, left._4, left._5, left._6, left._7, left._8, right)
+
+  //     override def unzip(out: (A, B, C, D, E, F, G, H, Z)): ((A, B, C, D, E, F, G, H), Z) =
+  //       ((out._1, out._2, out._3, out._4, out._5, out._6, out._7, out._8), out._9)
+  //   }
+
+  // implicit def Zipper10[A, B, C, D, E, F, G, H, I, Z]
+  //     : Zipper.WithOut[(A, B, C, D, E, F, G, H, I), Z, (A, B, C, D, E, F, G, H, I, Z)] =
+  //   new Zipper[(A, B, C, D, E, F, G, H, I), Z] {
+  //     type Out = (A, B, C, D, E, F, G, H, I, Z)
+  //     def zip(left: (A, B, C, D, E, F, G, H, I), right: Z): (A, B, C, D, E, F, G, H, I, Z) =
+  //       (left._1, left._2, left._3, left._4, left._5, left._6, left._7, left._8, left._9, right)
+
+  //     override def unzip(out: (A, B, C, D, E, F, G, H, I, Z)): ((A, B, C, D, E, F, G, H, I), Z) =
+  //       ((out._1, out._2, out._3, out._4, out._5, out._6, out._7, out._8, out._9), out._10)
+
+  //   }
+
+//  implicit def Zipper11[A, B, C, D, E, F, G, H, I, J, Z]
+//      : Zipper.WithOut[(A, B, C, D, E, F, G, H, I, J), Z, (A, B, C, D, E, F, G, H, I, J, Z)] =
+//    new Zipper[(A, B, C, D, E, F, G, H, I, J), Z] {
+//      type Out = (A, B, C, D, E, F, G, H, I, J, Z)
+//      def zip(left: (A, B, C, D, E, F, G, H, I, J), right: Z): (A, B, C, D, E, F, G, H, I, J, Z) =
+//        (left._1, left._2, left._3, left._4, left._5, left._6, left._7, left._8, left._9, left._10, right)
+//    }
+//
+//  implicit def Zipper12[A, B, C, D, E, F, G, H, I, J, K, Z]
+//      : Zipper.WithOut[(A, B, C, D, E, F, G, H, I, J, K), Z, (A, B, C, D, E, F, G, H, I, J, K, Z)] =
+//    new Zipper[(A, B, C, D, E, F, G, H, I, J, K), Z] {
+//      type Out = (A, B, C, D, E, F, G, H, I, J, K, Z)
+//      def zip(left: (A, B, C, D, E, F, G, H, I, J, K), right: Z): (A, B, C, D, E, F, G, H, I, J, K, Z) =
+//        (left._1, left._2, left._3, left._4, left._5, left._6, left._7, left._8, left._9, left._10, left._11, right)
+//    }
+//
+//  implicit def Zipper13[A, B, C, D, E, F, G, H, I, J, K, L, Z]
+//      : Zipper.WithOut[(A, B, C, D, E, F, G, H, I, J, K, L), Z, (A, B, C, D, E, F, G, H, I, J, K, L, Z)] =
+//    new Zipper[(A, B, C, D, E, F, G, H, I, J, K, L), Z] {
+//      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, Z)
+//      def zip(left: (A, B, C, D, E, F, G, H, I, J, K, L), right: Z): (A, B, C, D, E, F, G, H, I, J, K, L, Z) =
+//        (
+//          left._1,
+//          left._2,
+//          left._3,
+//          left._4,
+//          left._5,
+//          left._6,
+//          left._7,
+//          left._8,
+//          left._9,
+//          left._10,
+//          left._11,
+//          left._12,
+//          right
+//        )
+//    }
+//
+//  implicit def Zipper14[A, B, C, D, E, F, G, H, I, J, K, L, M, Z]
+//      : Zipper.WithOut[(A, B, C, D, E, F, G, H, I, J, K, L, M), Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, Z)] =
+//    new Zipper[(A, B, C, D, E, F, G, H, I, J, K, L, M), Z] {
+//      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, Z)
+//      def zip(left: (A, B, C, D, E, F, G, H, I, J, K, L, M), right: Z): (A, B, C, D, E, F, G, H, I, J, K, L, M, Z) =
+//        (
+//          left._1,
+//          left._2,
+//          left._3,
+//          left._4,
+//          left._5,
+//          left._6,
+//          left._7,
+//          left._8,
+//          left._9,
+//          left._10,
+//          left._11,
+//          left._12,
+//          left._13,
+//          right
+//        )
+//    }
+//
+//  implicit def Zipper15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, Z]
+//      : Zipper.WithOut[(A, B, C, D, E, F, G, H, I, J, K, L, M, N), Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, Z)] =
+//    new Zipper[(A, B, C, D, E, F, G, H, I, J, K, L, M, N), Z] {
+//      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, Z)
+//      def zip(
+//          left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N),
+//          right: Z
+//      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, Z) =
+//        (
+//          left._1,
+//          left._2,
+//          left._3,
+//          left._4,
+//          left._5,
+//          left._6,
+//          left._7,
+//          left._8,
+//          left._9,
+//          left._10,
+//          left._11,
+//          left._12,
+//          left._13,
+//          left._14,
+//          right
+//        )
+//    }
+//
+//  implicit def Zipper16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Z]
+//      : Zipper.WithOut[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O), Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Z)] =
+//    new Zipper[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O), Z] {
+//      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Z)
+//      def zip(
+//          left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O),
+//          right: Z
+//      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Z) =
+//        (
+//          left._1,
+//          left._2,
+//          left._3,
+//          left._4,
+//          left._5,
+//          left._6,
+//          left._7,
+//          left._8,
+//          left._9,
+//          left._10,
+//          left._11,
+//          left._12,
+//          left._13,
+//          left._14,
+//          left._15,
+//          right
+//        )
+//    }
+//
+//  implicit def Zipper17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Z]: Zipper.WithOut[
+//    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P),
+//    Z,
+//    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Z)
+//  ] =
+//    new Zipper[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P), Z] {
+//      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Z)
+//      def zip(
+//          left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P),
+//          right: Z
+//      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Z) =
+//        (
+//          left._1,
+//          left._2,
+//          left._3,
+//          left._4,
+//          left._5,
+//          left._6,
+//          left._7,
+//          left._8,
+//          left._9,
+//          left._10,
+//          left._11,
+//          left._12,
+//          left._13,
+//          left._14,
+//          left._15,
+//          left._16,
+//          right
+//        )
+//    }
+//
+//  implicit def Zipper18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Z]: Zipper.WithOut[
+//    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q),
+//    Z,
+//    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Z)
+//  ] =
+//    new Zipper[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q), Z] {
+//      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Z)
+//      def zip(
+//          left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q),
+//          right: Z
+//      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Z) =
+//        (
+//          left._1,
+//          left._2,
+//          left._3,
+//          left._4,
+//          left._5,
+//          left._6,
+//          left._7,
+//          left._8,
+//          left._9,
+//          left._10,
+//          left._11,
+//          left._12,
+//          left._13,
+//          left._14,
+//          left._15,
+//          left._16,
+//          left._17,
+//          right
+//        )
+//    }
+//
+//  implicit def Zipper19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Z]: Zipper.WithOut[
+//    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R),
+//    Z,
+//    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Z)
+//  ] =
+//    new Zipper[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R), Z] {
+//      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Z)
+//      def zip(
+//          left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R),
+//          right: Z
+//      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Z) =
+//        (
+//          left._1,
+//          left._2,
+//          left._3,
+//          left._4,
+//          left._5,
+//          left._6,
+//          left._7,
+//          left._8,
+//          left._9,
+//          left._10,
+//          left._11,
+//          left._12,
+//          left._13,
+//          left._14,
+//          left._15,
+//          left._16,
+//          left._17,
+//          left._18,
+//          right
+//        )
+//    }
+//
+//  implicit def Zipper20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Z]: Zipper.WithOut[
+//    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S),
+//    Z,
+//    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Z)
+//  ] =
+//    new Zipper[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S), Z] {
+//      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Z)
+//      def zip(
+//          left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S),
+//          right: Z
+//      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Z) =
+//        (
+//          left._1,
+//          left._2,
+//          left._3,
+//          left._4,
+//          left._5,
+//          left._6,
+//          left._7,
+//          left._8,
+//          left._9,
+//          left._10,
+//          left._11,
+//          left._12,
+//          left._13,
+//          left._14,
+//          left._15,
+//          left._16,
+//          left._17,
+//          left._18,
+//          left._19,
+//          right
+//        )
+//    }
+//
+//  implicit def Zipper21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Z]: Zipper.WithOut[
+//    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T),
+//    Z,
+//    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Z)
+//  ] =
+//    new Zipper[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T), Z] {
+//      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Z)
+//      def zip(
+//          left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T),
+//          right: Z
+//      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Z) =
+//        (
+//          left._1,
+//          left._2,
+//          left._3,
+//          left._4,
+//          left._5,
+//          left._6,
+//          left._7,
+//          left._8,
+//          left._9,
+//          left._10,
+//          left._11,
+//          left._12,
+//          left._13,
+//          left._14,
+//          left._15,
+//          left._16,
+//          left._17,
+//          left._18,
+//          left._19,
+//          left._20,
+//          right
+//        )
+//    }
+//
+//  implicit def Zipper22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Z]: Zipper.WithOut[
+//    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U),
+//    Z,
+//    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Z)
+//  ] =
+//    new Zipper[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U), Z] {
+//      type Out = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Z)
+//      def zip(
+//          left: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U),
+//          right: Z
+//      ): (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Z) =
+//        (
+//          left._1,
+//          left._2,
+//          left._3,
+//          left._4,
+//          left._5,
+//          left._6,
+//          left._7,
+//          left._8,
+//          left._9,
+//          left._10,
+//          left._11,
+//          left._12,
+//          left._13,
+//          left._14,
+//          left._15,
+//          left._16,
+//          left._17,
+//          left._18,
+//          left._19,
+//          left._20,
+//          left._21,
+//          right
+//        )
+//    }
+}
+
+trait ZipperLowPriority3 {
+
+  implicit def Zipper2[A, B]: Zipper.WithOut[A, B, (A, B)] =
+    new Zipper[A, B] {
+      type Out = (A, B)
+      def zip(left: A, right: B): Out = (left, right)
+
+      override def unzip(out: (A, B)): (A, B) =
+        out
+    }
+}

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/Zipper.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/Zipper.scala
@@ -7,6 +7,8 @@ trait Zipper[A, B] {
   type Out
   def zip(left: A, right: B): Out
   def unzip(out: Out): (A, B)
+
+  def zipSchema(left: Schema[A], right: Schema[B]): Schema[Out]
 }
 
 object Zipper extends ZipperLowPriority1 {
@@ -33,6 +35,9 @@ object Zipper extends ZipperLowPriority1 {
 
     override def unzip(out: A): (Unit, A) =
       ((), out)
+
+    override def zipSchema(left: Schema[Unit], right: Schema[A]): Schema[A] = 
+      right
   }
 
   def zipperLeftIdentitySchemaCase[A, B, C]: Schema.Case[ZipperLeftIdentity[Any], Zipper.WithOut[A, B, C]] =
@@ -69,6 +74,8 @@ trait ZipperLowPriority1 extends ZipperLowPriority2 {
 
     override def unzip(out: A): (A, Unit) =
       (out, ())
+
+    override def zipSchema(left: Schema[A], right: Schema[Unit]): Schema[A] = left
   }
 }
 
@@ -84,6 +91,9 @@ trait ZipperLowPriority2 extends ZipperLowPriority3 {
 
     override def unzip(out: (A, B, Z)): ((A, B), Z) =
       ((out._1, out._2), out._3)
+    
+    override def zipSchema(left: Schema[(A, B)], right: Schema[Z]): Schema[(A, B, Z)] = 
+      left.zip(right).transform((zip _).tupled, unzip)
   }
 
   implicit def zipper4[A, B, C, Z]: Zipper.WithOut[(A, B, C), Z, (A, B, C, Z)] = Zipper4[A, B, C, Z]()
@@ -95,6 +105,9 @@ trait ZipperLowPriority2 extends ZipperLowPriority3 {
 
     override def unzip(out: (A, B, C, Z)): ((A, B, C), Z) =
       ((out._1, out._2, out._3), out._4)
+
+    override def zipSchema(left: Schema[(A, B, C)], right: Schema[Z]): Schema[(A, B, C, Z)] = 
+      left.zip(right).transform((zip _).tupled, unzip)
   }
 
   implicit def zipper5[A, B, C, D, Z]: Zipper.WithOut[(A, B, C, D), Z, (A, B, C, D, Z)] = Zipper5[A, B, C, D, Z]()
@@ -106,6 +119,9 @@ trait ZipperLowPriority2 extends ZipperLowPriority3 {
 
     override def unzip(out: (A, B, C, D, Z)): ((A, B, C, D), Z) =
       ((out._1, out._2, out._3, out._4), out._5)
+    
+    override def zipSchema(left: Schema[(A, B, C, D)], right: Schema[Z]): Schema[(A, B, C, D, Z)] = 
+      left.zip(right).transform((zip _).tupled, unzip)
   }
 
   // implicit def Zipper6[A, B, C, D, E, Z]: Zipper.WithOut[(A, B, C, D, E), Z, (A, B, C, D, E, Z)] =
@@ -496,5 +512,8 @@ trait ZipperLowPriority3 {
 
     override def unzip(out: (A, B)): (A, B) =
       out
+
+    override def zipSchema(left: Schema[A], right: Schema[B]): Schema[(A, B)] = 
+      left.zip(right).transform((zip _).tupled, unzip)
   }
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/package.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/package.scala
@@ -1,0 +1,64 @@
+package zio.flow.operation
+
+import zhttp.service.{ChannelFactory, EventLoopGroup}
+import zio.json.{JsonCodec, JsonDecoder}
+import zio.flow.operation.http.API.NotUnit
+import zio.json.internal.{RetractReader, Write}
+import zio.schema.Schema
+
+import java.util.UUID
+import scala.language.implicitConversions
+import zio.ZIO
+
+package object http {
+
+  // Paths
+  val string: Path[String]   = Path.Match("string", Schema[String])
+  val int: Path[Int]         = Path.Match("int", Schema[Int])
+  val boolean: Path[Boolean] = Path.Match("boolean", Schema[Boolean])
+  val uuid: Path[UUID]       = Path.Match("uuid", Schema[UUID])
+
+  // Query Params
+  def string(name: String): Query[String]   = Query.SingleParam(name, Schema[String])
+  def int(name: String): Query[Int]         = Query.SingleParam(name, Schema[Int])
+  def boolean(name: String): Query[Boolean] = Query.SingleParam(name, Schema[Boolean])
+
+  implicit def stringToPath(string: String): Path[Unit] = Path.path(string)
+
+  // API Ops
+
+  implicit def apiToOps[Input, Output: NotUnit](
+      api: API[Input, Output]
+  ): APIOps[Input, Output, api.Id] =
+    new APIOps(api)
+
+  implicit def apiToOpsUnit[Input](
+      api: API[Input, Unit]
+  ): APIOpsUnit[Input, api.Id] =
+    new APIOpsUnit(api)
+
+  final class APIOps[Input, Output: NotUnit, Id](
+      val self: API.WithId[Input, Output, Id]
+  ){
+    def call(host: String)(params: Input): ZIO[EventLoopGroup with ChannelFactory, Throwable, Output] = {
+      ClientInterpreter.interpret(host)(self)(params).flatMap(_.bodyAsString).flatMap { string =>
+        self.outputCodec.decodeJson(string) match {
+          case Left(err)    => ZIO.fail(new Error(s"Could not parse response: $err"))
+          case Right(value) => ZIO.succeed(value)
+        }
+      }
+    }
+  }
+
+  final class APIOpsUnit[Input, Id](val self: API.WithId[Input, Unit, Id]){
+    def call(host: String)(params: Input): ZIO[EventLoopGroup with ChannelFactory, Throwable, Unit] = {
+      ClientInterpreter.interpret(host)(self)(params).unit
+    }
+  }
+
+  lazy implicit val unitCodec: JsonCodec[Unit] = JsonCodec(
+    (_: Unit, _: Option[Int], _: Write) => (),
+    (_: List[JsonDecoder.JsonError], _: RetractReader) => ()
+  )
+
+}

--- a/zio-flow/shared/src/main/scala/zio/flow/operation/http/package.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/operation/http/package.scala
@@ -1,6 +1,5 @@
 package zio.flow.operation
 
-import zhttp.service.{ChannelFactory, EventLoopGroup}
 import zio.json.{JsonCodec, JsonDecoder}
 import zio.flow.operation.http.API.NotUnit
 import zio.json.internal.{RetractReader, Write}
@@ -8,7 +7,6 @@ import zio.schema.Schema
 
 import java.util.UUID
 import scala.language.implicitConversions
-import zio.ZIO
 
 package object http {
 
@@ -28,33 +26,14 @@ package object http {
   // API Ops
 
   implicit def apiToOps[Input, Output: NotUnit](
-      api: API[Input, Output]
+    api: API[Input, Output]
   ): APIOps[Input, Output, api.Id] =
     new APIOps(api)
 
   implicit def apiToOpsUnit[Input](
-      api: API[Input, Unit]
+    api: API[Input, Unit]
   ): APIOpsUnit[Input, api.Id] =
     new APIOpsUnit(api)
-
-  final class APIOps[Input, Output: NotUnit, Id](
-      val self: API.WithId[Input, Output, Id]
-  ){
-    def call(host: String)(params: Input): ZIO[EventLoopGroup with ChannelFactory, Throwable, Output] = {
-      ClientInterpreter.interpret(host)(self)(params).flatMap(_.bodyAsString).flatMap { string =>
-        self.outputCodec.decodeJson(string) match {
-          case Left(err)    => ZIO.fail(new Error(s"Could not parse response: $err"))
-          case Right(value) => ZIO.succeed(value)
-        }
-      }
-    }
-  }
-
-  final class APIOpsUnit[Input, Id](val self: API.WithId[Input, Unit, Id]){
-    def call(host: String)(params: Input): ZIO[EventLoopGroup with ChannelFactory, Throwable, Unit] = {
-      ClientInterpreter.interpret(host)(self)(params).unit
-    }
-  }
 
   lazy implicit val unitCodec: JsonCodec[Unit] = JsonCodec(
     (_: Unit, _: Option[Int], _: Write) => (),

--- a/zio-flow/shared/src/test/scala/zio/flow/GoodcoverUseCase.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/GoodcoverUseCase.scala
@@ -1,11 +1,8 @@
 package zio.flow
 
-import zio.flow
 import zio.schema.{DeriveSchema, Schema}
 import zio.ZNothing
 import zio.test._
-
-import java.net.URI
 
 import zio.flow.operation.http
 

--- a/zio-flow/shared/src/test/scala/zio/flow/GoodcoverUseCase.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/GoodcoverUseCase.scala
@@ -7,6 +7,8 @@ import zio.test._
 
 import java.net.URI
 
+import zio.flow.operation.http
+
 object GoodcoverUseCase extends ZIOSpecDefault {
 
   def setBoolVarAfterSleep(
@@ -31,11 +33,8 @@ object GoodcoverUseCase extends ZIOSpecDefault {
     "get-policy-claim-status",
     "Returns whether or not claim was made on a policy for a certain year",
     Operation.Http[Policy, Boolean](
-      new URI("getPolicyClaimStatus.com"),
-      "GET",
-      Map.empty[String, String],
-      implicitly[Schema[Policy]],
-      implicitly[Schema[Boolean]]
+      "getPolicyClaimStatus.com",
+      http.API.get("").input[Policy].output[Boolean]
     ),
     ZFlow.succeed(true),
     ZFlow.unit
@@ -45,21 +44,10 @@ object GoodcoverUseCase extends ZIOSpecDefault {
     "get-fire-risk",
     "Gets the probability of fire hazard for a particular property",
     Operation.Http[Policy, Double](
-      new URI("getFireRiskForProperty.com"),
-      "GET",
-      Map.empty[String, String],
-      implicitly[Schema[Policy]],
-      implicitly[Schema[Double]]
+      "getFireRiskForProperty.com",
+      http.API.get("").input[Policy].output[Double]
     ),
     ZFlow.succeed(0.23),
-    ZFlow.unit
-  )
-
-  val reminderEmailForManualEvaluation: Activity[flow.EmailRequest, Unit] = Activity(
-    "send-reminder-email",
-    "Send out emails, can use third party service.",
-    Operation.SendEmail("Server", 22),
-    ZFlow.unit,
     ZFlow.unit
   )
 
@@ -67,11 +55,8 @@ object GoodcoverUseCase extends ZIOSpecDefault {
     "is-manual-evaluation-required",
     "Returns whether or not manual evaluation is required for this policy.",
     Operation.Http[(Policy, Double), Boolean](
-      new URI("isManualEvalRequired.com"),
-      "GET",
-      Map.empty[String, String],
-      implicitly[Schema[(Policy, Double)]],
-      implicitly[Schema[Boolean]]
+      "isManualEvalRequired.com",
+      http.API.get("").input[(Policy, Double)].output[Boolean]
     ),
     ZFlow.succeed(true),
     ZFlow.unit
@@ -95,8 +80,8 @@ object GoodcoverUseCase extends ZIOSpecDefault {
           _    <- setBoolVarAfterSleep(bool, 5, true).fork
           _    <- bool.waitUntil(_ === true).timeout(Remote.ofSeconds(1L))
           loop <- bool.get
-          _    <- ZFlow.log("Send reminder email to evaluator")
-          _    <- reminderEmailForManualEvaluation(emailRequest)
+          // _    <- ZFlow.log("Send reminder email to evaluator")
+          // _    <- reminderEmailForManualEvaluation(emailRequest)
         } yield !loop
       ),
     (b: Remote[Boolean]) => b
@@ -113,8 +98,8 @@ object GoodcoverUseCase extends ZIOSpecDefault {
         _    <- setBoolVarAfterSleep(bool, 5, true).fork
         _    <- bool.waitUntil(_ === true).timeout(Remote.ofSeconds(1L))
         loop <- bool.get
-        _    <- ZFlow.log("Send reminder email to customer for payment")
-        _    <- reminderEmailForManualEvaluation(emailRequest)
+        // _    <- ZFlow.log("Send reminder email to customer for payment")
+        // _    <- reminderEmailForManualEvaluation(emailRequest)
       } yield !loop),
     (b: Remote[Boolean]) => b
   )
@@ -124,11 +109,8 @@ object GoodcoverUseCase extends ZIOSpecDefault {
       "create-renewed-policy",
       "Creates a new Insurance Policy based on external params like previous claim, fire risk etc.",
       Operation.Http[(Boolean, Double), Option[Policy]](
-        new URI("createRenewedPolicy.com"),
-        "GET",
-        Map.empty[String, String],
-        implicitly[Schema[(Boolean, Double)]],
-        implicitly[Schema[Option[Policy]]]
+        "createRenewedPolicy.com",
+        http.API.get("").input[(Boolean, Double)].output[Option[Policy]]
       ),
       ZFlow.succeed(None),
       ZFlow.unit

--- a/zio-flow/shared/src/test/scala/zio/flow/internal/PersistentExecutorSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/internal/PersistentExecutorSpec.scala
@@ -12,7 +12,8 @@ import java.net.URI
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
-
+import zio.flow.operation.http.API
+import zio.flow.operation.http
 object PersistentExecutorSpec extends ZIOFlowBaseSpec {
 
   private val unit: Unit = ()
@@ -23,11 +24,8 @@ object PersistentExecutorSpec extends ZIOFlowBaseSpec {
       "Test Activity",
       "Mock activity created for test",
       Operation.Http[Int, Int](
-        new URI("testUrlForActivity.com"),
-        "GET",
-        Map.empty[String, String],
-        Schema[Int],
-        Schema[Int]
+        "testUrlForActivity.com",
+        API.get("").input[Int].output[Int]
       ),
       ZFlow.succeed(12),
       ZFlow.unit
@@ -268,21 +266,21 @@ object PersistentExecutorSpec extends ZIOFlowBaseSpec {
         val activity1Undo1 = Activity(
           "activity1Undo1",
           "activity1Undo1",
-          Operation.Http(new URI("http://activity1/undo/1"), "GET", Map.empty, Schema[Int], Schema[Int]),
+          Operation.Http("http://activity1/undo/1", API.get("").input[Int].output[Int]),
           ZFlow.succeed(0),
           ZFlow.unit
         )
         val activity1Undo2 = Activity(
           "activity1Undo2",
           "activity1Undo2",
-          Operation.Http(new URI("http://activity1/undo/2"), "GET", Map.empty, Schema[Int], Schema[Int]),
+          Operation.Http("http://activity1/undo/2", API.get("").input[Int].output[Int]),
           ZFlow.succeed(0),
           ZFlow.unit
         )
         val activity2Undo = Activity(
           "activity2Undo",
           "activity2Undo",
-          Operation.Http(new URI("http://activity2/undo"), "GET", Map.empty, Schema[Int], Schema[Int]),
+          Operation.Http("http://activity2/undo", API.get("").input[Int].output[Int]),
           ZFlow.succeed(0),
           ZFlow.unit
         )
@@ -290,14 +288,14 @@ object PersistentExecutorSpec extends ZIOFlowBaseSpec {
         val activity1 = Activity(
           "activity1",
           "activity1",
-          Operation.Http(new URI("http://activity1"), "GET", Map.empty, Schema[Int], Schema[Int]),
+          Operation.Http("http://activity1", API.get("").input[Int].output[Int]),
           ZFlow.succeed(0),
           ZFlow.input[Int].flatMap(n => activity1Undo1(n) *> activity1Undo2(n)).unit
         )
         val activity2 = Activity(
           "activity2",
           "activity2",
-          Operation.Http(new URI("http://activity2"), "POST", Map.empty, Schema[Int], Schema[Int]),
+          Operation.Http("http://activity2", API.post("").input[Int].output[Int]),
           ZFlow.succeed(0),
           ZFlow.input[Int].flatMap(n => activity2Undo(n)).unit
         )
@@ -381,14 +379,14 @@ object PersistentExecutorSpec extends ZIOFlowBaseSpec {
         val activity1Undo = Activity(
           "activity1Undo",
           "activity1Undo",
-          Operation.Http(new URI("http://activity1/undo"), "GET", Map.empty, Schema[Int], Schema[Int]),
+          Operation.Http("http://activity1/undo", API.get("").input[Int].output[Int]),
           ZFlow.succeed(0),
           ZFlow.unit
         )
         val activity2Undo = Activity(
           "activity2Undo",
           "activity2Undo",
-          Operation.Http(new URI("http://activity2/undo"), "GET", Map.empty, Schema[Int], Schema[Int]),
+          Operation.Http("http://activity2/undo", API.get("").input[Int].output[Int]),
           ZFlow.succeed(0),
           ZFlow.unit
         )
@@ -396,14 +394,14 @@ object PersistentExecutorSpec extends ZIOFlowBaseSpec {
         val activity1 = Activity(
           "activity1",
           "activity1",
-          Operation.Http(new URI("http://activity1"), "GET", Map.empty, Schema[Int], Schema[Int]),
+          Operation.Http("http://activity1", API.get("").input[Int].output[Int]),
           ZFlow.succeed(0),
           ZFlow.input[Int].flatMap(n => activity1Undo(n)).unit
         )
         val activity2 = Activity(
           "activity2",
           "activity2",
-          Operation.Http(new URI("http://activity2"), "POST", Map.empty, Schema[Int], Schema[Int]),
+          Operation.Http("http://activity2", API.post("").input[Int].output[Int]),
           ZFlow.succeed(0),
           ZFlow.input[Int].flatMap(n => activity2Undo(n)).unit
         )

--- a/zio-flow/shared/src/test/scala/zio/flow/internal/PersistentExecutorSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/internal/PersistentExecutorSpec.scala
@@ -13,7 +13,6 @@ import java.time.Instant
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import zio.flow.operation.http.API
-import zio.flow.operation.http
 object PersistentExecutorSpec extends ZIOFlowBaseSpec {
 
   private val unit: Unit = ()

--- a/zio-flow/shared/src/test/scala/zio/flow/mock/MockedOperation.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/mock/MockedOperation.scala
@@ -43,10 +43,11 @@ object MockedOperation {
   ) extends MockedOperation {
     override def matchOperation[R1, A1](operation: Operation[R1, A1], input: R1): (Option[Match[A1]], MockedOperation) =
       operation match {
-        case Operation.Http(url, method, headers, _, _) =>
+        case Operation.Http(url, api) =>
           // TODO: check R1 and A1 types too
+          // TODO: check headers as well
           val m =
-            urlMatcher.run(url) && methodMatcher.run(method) && headersMatcher.run(headers) && inputMatcher.run(
+            urlMatcher.run(new URI(url)) && methodMatcher.run(api.method.toString()) && inputMatcher.run(
               input.asInstanceOf[R]
             )
           if (m.isSuccess) {
@@ -54,8 +55,6 @@ object MockedOperation {
           } else {
             (None, this)
           }
-        case Operation.SendEmail(_, _) =>
-          (None, this)
       }
   }
 

--- a/zio-flow/shared/src/test/scala/zio/flow/utils/MocksForGCExample.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/utils/MocksForGCExample.scala
@@ -11,17 +11,13 @@ object MocksForGCExample {
     new OperationExecutor[Console with Clock] {
       override def execute[I, A](input: I, operation: Operation[I, A]): ZIO[Console with Clock, ActivityError, A] =
         operation match {
-          case Operation.Http(url, _, _, _, _) =>
+          case Operation.Http(url, _) =>
             Console
-              .printLine(s"Request to : ${url.toString}")
+              .printLine(s"Request to : $url")
               .mapBoth(
                 error => ActivityError("Failed to write to console", Some(error)),
-                _ => map(url).asInstanceOf[A]
+                _ => map(new URI(url)).asInstanceOf[A]
               )
-          case Operation.SendEmail(_, _) =>
-            Console
-              .printLine("Sending email")
-              .mapBoth(error => ActivityError("Failed to write to console", Some(error)), _.asInstanceOf[A])
         }
     }
 


### PR DESCRIPTION
Http operation DSL based on @kitlangton's [zio-api](https://github.com/kitlangton/zio-api.git). Notable changes to zio-api:
- removed the parts related to http request handling
- merged the `Input` and `Params` type in `API`. This way it has an `Input` and `Output` type that correlates directly with the types on zio-flow's `Operation`. 

The idea is that query parameters, paths segments, headers and the request body will all be part of the Activity's input, so it can be used like this:

```scala
  val setUserData = Activity[(Int, UserData), Unit](
    "setUserData",
    "set user data",
    Operation.Http(
      "https://example.com",
      API.post("users" / int).input[UserData]
    ),
    check = ???,
    compensate = ZFlow.succeed(())
  )

  val flow = for {
    id   <- ZFlow.succeed(1)
    data <- ZFlow.succeed(UserData("Albert"))
    _    <- setUserData(id, data)
  } yield ()

```

Two issues I am still working on:
1. Defining the schema on the Http operation's `Input` type. I don't know if this schema should be built from the ground-up and defined on every `RequestInput` in `path.scala`, or we should just require an `implicit Schema[Input]` when creating the Http operation.
2. The Http operation, with `API` itself  has to be serializable. One tricky thing with implementing that is that in `Path.scala`, the description of request inputs are having unzipping functions as fields, and I don't know yet how this description should be serialised.

Edit: both problems are solved now, there are some other issues with tests which I am still working on.