### PR TITLE
Some renames and a better type for remote functions to avoid miuse

### DIFF
--- a/zio-flow/shared/src/main/scala/zio/flow/Mappable.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/Mappable.scala
@@ -16,7 +16,7 @@
 
 package zio.flow
 
-import zio.flow.Remote.EvaluatedRemoteFunction
+import zio.flow.Remote.UnboundRemoteFunction
 
 sealed trait Mappable[F[_]] {
   def performMap[A, B](fa: Remote[F[A]], ab: Remote[A] => Remote[B]): Remote[F[B]]
@@ -36,7 +36,7 @@ object Mappable {
       Remote.FoldOption(
         fa,
         Remote.none,
-        EvaluatedRemoteFunction.make((a: Remote[A]) => Remote.RemoteSome(ab(a)))
+        UnboundRemoteFunction.make((a: Remote[A]) => Remote.RemoteSome(ab(a)))
       )
 
     override def performFilter[A](
@@ -46,14 +46,14 @@ object Mappable {
       Remote.FoldOption(
         fa,
         Remote.none,
-        EvaluatedRemoteFunction.make((a: Remote[A]) => predicate(a).ifThenElse(fa, Remote.none[A]))
+        UnboundRemoteFunction.make((a: Remote[A]) => predicate(a).ifThenElse(fa, Remote.none[A]))
       )
 
     override def performFlatmap[A, B](
       fa: Remote[Option[A]],
       ab: Remote[A] => Remote[Option[B]]
     ): Remote[Option[B]] =
-      Remote.FoldOption(fa, Remote.none[B], EvaluatedRemoteFunction.make(ab))
+      Remote.FoldOption(fa, Remote.none[B], UnboundRemoteFunction.make(ab))
   }
 
   implicit case object MappableList extends Mappable[List] {
@@ -62,7 +62,7 @@ object Mappable {
       Remote.Fold(
         fa,
         Remote.nil,
-        EvaluatedRemoteFunction.make((tuple: Remote[(List[B], A)]) => Remote.Cons(tuple._1, ab(tuple._2)))
+        UnboundRemoteFunction.make((tuple: Remote[(List[B], A)]) => Remote.Cons(tuple._1, ab(tuple._2)))
       )
 
     override def performFilter[A](
@@ -72,7 +72,7 @@ object Mappable {
       Remote.Fold(
         fa,
         Remote.nil,
-        EvaluatedRemoteFunction.make((tuple: Remote[(List[A], A)]) =>
+        UnboundRemoteFunction.make((tuple: Remote[(List[A], A)]) =>
           predicate(tuple._2).ifThenElse(Remote.Cons(tuple._1, tuple._2), tuple._1)
         )
       )
@@ -84,7 +84,7 @@ object Mappable {
       Remote.Fold(
         fa,
         Remote.nil,
-        EvaluatedRemoteFunction.make((tuple: Remote[(List[B], A)]) => tuple._1 ++ ab(tuple._2))
+        UnboundRemoteFunction.make((tuple: Remote[(List[B], A)]) => tuple._1 ++ ab(tuple._2))
       )
   }
 

--- a/zio-flow/shared/src/main/scala/zio/flow/debug/PrettyPrint.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/debug/PrettyPrint.scala
@@ -63,11 +63,11 @@ object PrettyPrint {
         builder.append("<")
         builder.append(BindingName.unwrap(identifier))
         builder.append(">")
-      case Remote.EvaluatedRemoteFunction(input, result) =>
+      case Remote.UnboundRemoteFunction(input, result) =>
         prettyPrintRemote(input, builder, indent)
         builder.append(" => ")
         prettyPrintRemote(result, builder, indent)
-      case Remote.ApplyEvaluatedFunction(f, a) =>
+      case Remote.EvaluateUnboundRemoteFunction(f, a) =>
         prettyPrintRemote(f, builder, indent)
         builder.append(" called with ")
         prettyPrintRemote(a, builder, indent)

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteEitherSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteEitherSyntax.scala
@@ -16,7 +16,7 @@
 
 package zio.flow.remote
 
-import zio.flow.Remote.EvaluatedRemoteFunction
+import zio.flow.Remote.UnboundRemoteFunction
 import zio.flow.{Remote, ZFlow}
 
 import scala.util.Try
@@ -24,7 +24,7 @@ import scala.util.Try
 final class RemoteEitherSyntax[A, B](val self: Remote[Either[A, B]]) extends AnyVal {
 
   def fold[C](left: Remote[A] => Remote[C], right: Remote[B] => Remote[C]): Remote[C] =
-    Remote.FoldEither[A, B, C](self, EvaluatedRemoteFunction.make(left), EvaluatedRemoteFunction.make(right))
+    Remote.FoldEither[A, B, C](self, UnboundRemoteFunction.make(left), UnboundRemoteFunction.make(right))
 
   def handleEitherFlow[R, E, C](
     left: Remote[A] => ZFlow[R, E, C],
@@ -34,7 +34,7 @@ final class RemoteEitherSyntax[A, B](val self: Remote[Either[A, B]]) extends Any
   def flatMap[A1 >: A, B1](f: Remote[B] => Remote[Either[A1, B1]]): Remote[Either[A1, B1]] =
     Remote.FoldEither[A1, B, Either[A1, B1]](
       self,
-      EvaluatedRemoteFunction.make((a: Remote[A1]) => Remote.RemoteEither(Left(a))),
+      UnboundRemoteFunction.make((a: Remote[A1]) => Remote.RemoteEither(Left(a))),
       f
     )
 
@@ -43,8 +43,8 @@ final class RemoteEitherSyntax[A, B](val self: Remote[Either[A, B]]) extends Any
   ): Remote[Either[A, B1]] =
     Remote.FoldEither[A, B, Either[A, B1]](
       self,
-      EvaluatedRemoteFunction.make((a: Remote[A]) => Remote.RemoteEither(Left(a))),
-      EvaluatedRemoteFunction.make((b: Remote[B]) => Remote.RemoteEither(Right(f(b))))
+      UnboundRemoteFunction.make((a: Remote[A]) => Remote.RemoteEither(Left(a))),
+      UnboundRemoteFunction.make((b: Remote[B]) => Remote.RemoteEither(Right(f(b))))
     )
 
   def flatten[A1 >: A, B1](implicit
@@ -55,8 +55,8 @@ final class RemoteEitherSyntax[A, B](val self: Remote[Either[A, B]]) extends Any
   def merge(implicit ev: Either[A, B] <:< Either[B, B]): Remote[B] =
     Remote.FoldEither[B, B, B](
       self.widen[Either[B, B]],
-      EvaluatedRemoteFunction.make(identity[Remote[B]]),
-      EvaluatedRemoteFunction.make(identity[Remote[B]])
+      UnboundRemoteFunction.make(identity[Remote[B]]),
+      UnboundRemoteFunction.make(identity[Remote[B]])
     )
 
   def isLeft: Remote[Boolean] =

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteListSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteListSyntax.scala
@@ -16,7 +16,7 @@
 
 package zio.flow.remote
 
-import zio.flow.Remote.EvaluatedRemoteFunction
+import zio.flow.Remote.UnboundRemoteFunction
 import zio.flow._
 import zio.flow.remote.numeric._
 
@@ -72,7 +72,7 @@ final class RemoteListSyntax[A](val self: Remote[List[A]]) extends AnyVal {
   def fold[B](initial: Remote[B])(
     f: (Remote[B], Remote[A]) => Remote[B]
   ): Remote[B] =
-    Remote.Fold(self, initial, EvaluatedRemoteFunction.make((tuple: Remote[(B, A)]) => f(tuple._1, tuple._2)))
+    Remote.Fold(self, initial, UnboundRemoteFunction.make((tuple: Remote[(B, A)]) => f(tuple._1, tuple._2)))
 
   def headOption1: Remote[Option[A]] = Remote
     .UnCons(self)

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteOptionSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteOptionSyntax.scala
@@ -16,14 +16,14 @@
 
 package zio.flow.remote
 
-import zio.flow.Remote.EvaluatedRemoteFunction
+import zio.flow.Remote.UnboundRemoteFunction
 import zio.flow._
 import zio.schema.DeriveSchema.gen
 
 final class RemoteOptionSyntax[A](val self: Remote[Option[A]]) extends AnyVal {
 
   def fold[B](forNone: Remote[B], f: Remote[A] => Remote[B]): Remote[B] =
-    Remote.FoldOption(self, forNone, EvaluatedRemoteFunction.make(f))
+    Remote.FoldOption(self, forNone, UnboundRemoteFunction.make(f))
 
   def isSome: Remote[Boolean] =
     fold(Remote(false), _ => Remote(true))

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteVariableReferenceSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteVariableReferenceSyntax.scala
@@ -18,7 +18,7 @@ package zio.flow.remote
 
 import zio.flow._
 import zio.ZNothing
-import zio.flow.Remote.EvaluatedRemoteFunction
+import zio.flow.Remote.UnboundRemoteFunction
 
 class RemoteVariableReferenceSyntax[A](val self: Remote[RemoteVariableReference[A]]) extends AnyVal {
 
@@ -49,7 +49,7 @@ class RemoteVariableReferenceSyntax[A](val self: Remote[RemoteVariableReference[
   def modify[B](
     f: Remote[A] => (Remote[B], Remote[A])
   ): ZFlow[Any, ZNothing, B] =
-    ZFlow.Modify(self, EvaluatedRemoteFunction.make((a: Remote[A]) => Remote.tuple2(f(a))))
+    ZFlow.Modify(self, UnboundRemoteFunction.make((a: Remote[A]) => Remote.tuple2(f(a))))
 
   /**
    * Updates the value stored in a remote variable using the given function, and

--- a/zio-flow/shared/src/test/scala/zio/flow/remote/RemoteSpec.scala
+++ b/zio-flow/shared/src/test/scala/zio/flow/remote/RemoteSpec.scala
@@ -182,7 +182,7 @@ object RemoteSpec extends RemoteSpecBase {
           val remote = Remote.Fold(
             Remote(List(10, 20, 30)),
             Remote(100),
-            Remote.EvaluatedRemoteFunction.make((tuple: Remote[(Int, Int)]) =>
+            Remote.UnboundRemoteFunction.make((tuple: Remote[(Int, Int)]) =>
               Remote.BinaryNumeric(
                 Remote.TupleAccess(tuple, 0),
                 Remote.TupleAccess(tuple, 1),
@@ -206,7 +206,7 @@ object RemoteSpec extends RemoteSpecBase {
           val remote = Remote.Fold(
             Remote(List(TestCaseClass("a", 10), TestCaseClass("b", 20), TestCaseClass("c", 30))),
             Remote(TestCaseClass("d", 40)),
-            Remote.EvaluatedRemoteFunction.make((tuple: Remote[(TestCaseClass, TestCaseClass)]) =>
+            Remote.UnboundRemoteFunction.make((tuple: Remote[(TestCaseClass, TestCaseClass)]) =>
               Remote.TupleAccess[(TestCaseClass, TestCaseClass), TestCaseClass](tuple, 1)
             )
           )


### PR DESCRIPTION
Resolves https://github.com/zio/zio-flow/issues/219

Minor changes to better represent remote functions and avoid some misusage:

- Renamed `EvaluatedRemoteFunction` to `UnboundRemoteFunction` as it represents a remote with `Unbound` variables in it.
- The type of `UnboundRemoteFunction` is no longer `Remote[B]` which allowed the misuse presented in #219 but `Remote[EvaluatedRemoteFunction[A, B]]` representing that it is a value of an evaluated function.
- `EvaluatedRemoteFunction` is just a newtype for `DynamicValue`, not adding any overhead
- Renamed `ApplyRemoteFunction` to `EvaluateUnboundRemoteFunction` to better match these changes

The example in #219 no longer type checks.