### PR TITLE
Chunk syntax

### DIFF
--- a/zio-flow-runtime/src/test/scala/zio/flow/remote/RemoteChunkSyntaxSpec.scala
+++ b/zio-flow-runtime/src/test/scala/zio/flow/remote/RemoteChunkSyntaxSpec.scala
@@ -1,0 +1,545 @@
+/*
+ * Copyright 2021-2022 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.flow.remote
+
+import zio.flow.debug.TrackRemotes._
+import zio.flow.runtime.internal.InMemoryRemoteContext
+import zio.{Chunk, Scope, ZLayer}
+import zio.flow.{LocalContext, Remote}
+import zio.flow.utils.RemoteAssertionSyntax.RemoteAssertionOps
+import zio.test.{Spec, TestEnvironment}
+
+object RemoteChunkSyntaxSpec extends RemoteSpecBase {
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("RemoteChunkSyntax")(
+      remoteTest("Remote.emptyChunk")(
+        Remote.emptyChunk[Int] <-> Chunk.empty[Int]
+      ),
+      remoteTest("Remote.chunk")(
+        Remote.chunk(1, 2, 3) <-> Chunk(1, 2, 3)
+      ),
+      remoteTest("++")(
+        Remote.chunk(1, 2, 3, 4) ++ Remote.chunk(5, 6, 7) <-> Chunk(1, 2, 3, 4, 5, 6, 7),
+        Remote.chunk(1, 2, 3, 4) ++ Remote.emptyChunk[Int] <-> Chunk(1, 2, 3, 4),
+        Remote.emptyChunk[Int] ++ Remote.chunk(1, 2, 3, 4) <-> Chunk(1, 2, 3, 4),
+        Remote.emptyChunk[Int] ++ Remote.emptyChunk[Int] <-> Chunk.empty
+      ),
+      remoteTest("++:")(
+        Remote.chunk(1, 2, 3, 4) ++: Remote.chunk(5, 6, 7) <-> Chunk(1, 2, 3, 4, 5, 6, 7),
+        Remote.chunk(1, 2, 3, 4) ++: Remote.emptyChunk[Int] <-> Chunk(1, 2, 3, 4),
+        Remote.emptyChunk[Int] ++: Remote.chunk(1, 2, 3, 4) <-> Chunk(1, 2, 3, 4),
+        Remote.emptyChunk[Int] ++: Remote.emptyChunk[Int] <-> Chunk.empty
+      ),
+      remoteTest("+:")(
+        Remote(1) +: Remote.emptyChunk[Int] <-> Chunk(1),
+        Remote(1) +: Remote.chunk(2, 3) <-> Chunk(1, 2, 3)
+      ),
+      remoteTest(":+")(
+        Remote.emptyChunk[Int] :+ Remote(1) <-> Chunk(1),
+        Remote.chunk(2, 3) :+ Remote(1) <-> Chunk(2, 3, 1)
+      ),
+      remoteTest(":++")(
+        Remote.chunk(1, 2, 3, 4) :++ Remote.chunk(5, 6, 7) <-> Chunk(1, 2, 3, 4, 5, 6, 7),
+        Remote.chunk(1, 2, 3, 4) :++ Remote.emptyChunk[Int] <-> Chunk(1, 2, 3, 4),
+        Remote.emptyChunk[Int] :++ Remote.chunk(1, 2, 3, 4) <-> Chunk(1, 2, 3, 4),
+        Remote.emptyChunk[Int] :++ Remote.emptyChunk[Int] <-> Chunk.empty
+      ),
+      remoteTest("appended")(
+        Remote.emptyChunk[Int].appended(Remote(1)) <-> Chunk(1),
+        Remote.chunk(2, 3).appended(Remote(1)) <-> Chunk(2, 3, 1)
+      ),
+      remoteTest("appendedAll")(
+        Remote.chunk(1, 2, 3, 4).appendedAll(Remote.chunk(5, 6, 7)) <-> Chunk(1, 2, 3, 4, 5, 6, 7),
+        Remote.chunk(1, 2, 3, 4).appendedAll(Remote.emptyChunk[Int]) <-> Chunk(1, 2, 3, 4),
+        Remote.emptyChunk[Int].appendedAll(Remote.chunk(1, 2, 3, 4)) <-> Chunk(1, 2, 3, 4),
+        Remote.emptyChunk[Int].appendedAll(Remote.emptyChunk[Int]) <-> Chunk.empty
+      ),
+      remoteTest("apply")(
+        Remote.emptyChunk[Int].apply(0) failsWithRemoteFailure ("get called on empty Option"),
+        Remote.chunk(1, 2, 3).apply(1) <-> 2
+      ),
+      remoteTest("concat")(
+        Remote.chunk(1, 2, 3, 4).concat(Remote.chunk(5, 6, 7)) <-> Chunk(1, 2, 3, 4, 5, 6, 7),
+        Remote.chunk(1, 2, 3, 4).concat(Remote.emptyChunk[Int]) <-> Chunk(1, 2, 3, 4),
+        Remote.emptyChunk[Int].concat(Remote.chunk(1, 2, 3, 4)) <-> Chunk(1, 2, 3, 4),
+        Remote.emptyChunk[Int].concat(Remote.emptyChunk[Int]) <-> Chunk.empty
+      ),
+      remoteTest("contains")(
+        Remote.emptyChunk[Int].contains(10) <-> false,
+        Remote.chunk(1, 2, 3).contains(10) <-> false,
+        Remote.chunk(9, 10, 11).contains(10) <-> true
+      ),
+      remoteTest("containsSlice")(
+        Remote.emptyChunk[Int].containsSlice(Remote.chunk(1, 2)) <-> false,
+        Remote.chunk(1, 2, 3, 4).containsSlice(Remote.chunk(2, 3)) <-> true,
+        Remote.chunk(1, 2, 3).containsSlice(Remote.chunk(2, 3)) <-> true,
+        Remote.chunk(1, 2).containsSlice(Remote.chunk(2, 3)) <-> false
+      ),
+      remoteTest("corresponds")(
+        Remote
+          .chunk(1, 2, 3)
+          .corresponds(Remote.chunk("x", "xx", "xxx"))((n: Remote[Int], s: Remote[String]) => s.length === n) <-> true,
+        Remote
+          .chunk(1, 2, 1)
+          .corresponds(Remote.chunk("x", "xx", "xxx"))((n: Remote[Int], s: Remote[String]) => s.length === n) <-> false
+      ),
+      remoteTest("count")(
+        Remote.emptyChunk[Int].count(_ % 2 === 0) <-> 0,
+        Remote.chunk(1, 2, 3, 4, 5).count(_ % 2 === 0) <-> 2
+      ),
+      remoteTest("diff")(
+        Remote.chunk(1, 2, 3, 4).diff(Remote.chunk(2, 4)) <-> Chunk(1, 3),
+        Remote.chunk(1, 2, 3, 4).diff(Remote.emptyChunk[Int]) <-> Chunk(1, 2, 3, 4),
+        Remote.emptyChunk[Int].diff(Remote.chunk(1, 2)) <-> Chunk.empty
+      ),
+      remoteTest("distinct")(
+        Remote.emptyChunk[Int].distinct <-> Chunk.empty[Int],
+        Remote.chunk(1, 2, 3, 2, 1).distinct <-> Chunk(1, 2, 3)
+      ),
+      remoteTest("distinctBy")(
+        Remote.chunk("abc", "axy", "bca", "bb", "c").distinctBy(_.length) <-> Chunk("abc", "bb", "c"),
+        Remote.emptyChunk[String].distinctBy(_.length) <-> Chunk.empty[String]
+      ),
+      remoteTest("drop")(
+        Remote.emptyChunk[Int].drop(10) <-> Chunk.empty[Int],
+        Remote.chunk(1, 2, 3).drop(0) <-> Chunk(1, 2, 3),
+        Remote.chunk(1, 2, 3).drop(2) <-> Chunk(3),
+        Remote.chunk(1, 2, 3).drop(4) <-> Chunk.empty[Int]
+      ),
+      remoteTest("dropWhile")(
+        Remote.emptyChunk[Int].dropWhile(_ < 3) <-> Chunk.empty[Int],
+        Remote.chunk(1, 2, 3, 4).dropWhile(_ < 3) <-> Chunk(3, 4)
+      ),
+      remoteTest("endsWith")(
+        Remote.emptyChunk[Int].endsWith(Remote.chunk(1, 2)) <-> false,
+        Remote.chunk(1, 2, 3).endsWith(Remote.chunk(1, 2)) <-> false,
+        Remote.chunk(0, 0, 1, 2).endsWith(Remote.chunk(1, 2)) <-> true
+      ),
+      remoteTest("exists")(
+        Remote.emptyChunk[Int].exists(_ % 2 === 0) <-> false,
+        Remote.chunk(1, 3, 5, 7).exists(_ % 2 === 0) <-> false,
+        Remote.chunk(1, 3, 4, 7).exists(_ % 2 === 0) <-> true
+      ),
+      remoteTest("filter")(
+        Remote.emptyChunk[Int].filter(_ % 2 === 0) <-> Chunk.empty[Int],
+        Remote.chunk(1, 3, 5, 7).filter(_ % 2 === 0) <-> Chunk.empty[Int],
+        Remote.chunk(1, 3, 4, 7).filter(_ % 2 === 0) <-> Chunk(4)
+      ),
+      remoteTest("filterNot")(
+        Remote.emptyChunk[Int].filterNot(_ % 2 === 0) <-> Chunk.empty[Int],
+        Remote.chunk(1, 3, 5, 7).filterNot(_ % 2 === 0) <-> Chunk(1, 3, 5, 7),
+        Remote.chunk(1, 3, 4, 7).filterNot(_ % 2 === 0) <-> Chunk(1, 3, 7)
+      ),
+      remoteTest("find")(
+        Remote.emptyChunk[Int].find(_ === 3) <-> None,
+        Remote.chunk(1, 2, 4, 5).find(_ === 3) <-> None,
+        Remote.chunk(1, 2, 3, 4).find(_ === 3) <-> Some(3),
+        Remote.chunk("aaa", "b", "ccc", "d").find(_.length === 3) <-> Some("aaa")
+      ),
+      remoteTest("findLast")(
+        Remote.emptyChunk[String].findLast(_.length === 3) <-> None,
+        Remote.chunk("aa", "bb", "cc").findLast(_.length === 3) <-> None,
+        Remote.chunk("aaa", "b", "ccc", "d").findLast(_.length === 3) <-> Some("ccc")
+      ),
+      remoteTest("flatMap")(
+        Remote.emptyChunk[Int].flatMap(_ => Remote.chunk(1, 2, 3)) <-> Chunk.empty[Int],
+        Remote.chunk(1, 2, 3).flatMap((n: Remote[Int]) => Remote.chunk(n) ++ Remote.chunk(2, 3)) <-> Chunk(1, 2, 3, 2,
+          2, 3, 3, 2, 3),
+        Remote.chunk(1, 2, 3).flatMap(_ => Remote.emptyChunk[Int]) <-> Chunk.empty[Int]
+      ),
+      remoteTest("flatten")(
+        Remote.emptyChunk[Chunk[Int]].flatten <-> Chunk.empty[Int],
+        Remote.chunk(Remote.emptyChunk[Int], Remote.emptyChunk[Int]).flatten <-> Chunk.empty[Int],
+        Remote.chunk(Remote.chunk(1, 2), Remote.chunk(3, 4)).flatten <-> Chunk(1, 2, 3, 4)
+      ),
+      remoteTest("foldLeft")(
+        Remote.chunk(1.0, 2.0, 3.0).foldLeft(4.0)(_ / _) <-> Chunk(1.0, 2.0, 3.0).foldLeft(4.0)(_ / _),
+        Remote.emptyChunk[Double].foldLeft(4.0)(_ / _) <-> 4.0
+      ),
+      remoteTest("foldRight")(
+        Remote.chunk(1.0, 2.0, 3.0).foldRight(4.0)(_ / _) <-> Chunk(1.0, 2.0, 3.0).foldRight(4.0)(_ / _),
+        Remote.emptyChunk[Double].foldRight(4.0)(_ / _) <-> 4.0
+      ),
+      remoteTest("forall")(
+        Remote.emptyChunk[Int].forall(_ % 2 === 0) <-> true,
+        Remote.chunk(1, 2, 3, 4).forall(_ % 2 === 0) <-> false,
+        Remote.chunk(2, 4, 6, 8).forall(_ % 2 === 0) <-> true
+      ),
+      remoteTest("head")(
+        Remote.emptyChunk[Int].head failsWithRemoteFailure "List is empty",
+        Remote.chunk(1, 2, 3).head <-> 1
+      ),
+      remoteTest("headOption")(
+        Remote.emptyChunk[Int].headOption <-> None,
+        Remote.chunk(1, 2, 3).headOption <-> Some(1)
+      ),
+      remoteTest("indexOf")(
+        Remote.emptyChunk[Int].indexOf(3) <-> -1,
+        Remote.chunk(1, 2, 4, 5).indexOf(3) <-> -1,
+        Remote.chunk(1, 2, 3, 4).indexOf(3) <-> 2,
+        Remote.chunk(1, 2, 3, 4).indexOf(3, 2) <-> 2,
+        Remote.chunk(1, 2, 3, 4, 4, 3).indexOf(3, 3) <-> 5
+      ),
+      remoteTest("indexOfSlice")(
+        Remote.emptyChunk[Int].indexOfSlice(Chunk(2, 3)) <-> -1,
+        Remote.chunk(1, 2, 3, 4, 5, 2, 3, 6).indexOfSlice(Chunk(2, 3)) <-> 1,
+        Remote.chunk(1, 2, 3, 4, 5, 2, 3, 6).indexOfSlice(Chunk(2, 3), 1) <-> 1,
+        Remote.chunk(1, 2, 3, 4, 5, 2, 3, 6).indexOfSlice(Chunk(2, 3), 3) <-> 5
+      ),
+      remoteTest("indexWhere")(
+        Remote.emptyChunk[Int].indexWhere(_ % 2 === 0) <-> -1,
+        Remote.chunk(1, 2, 3, 4, 5, 2, 3, 6).indexWhere(_ % 2 === 0) <-> 1,
+        Remote.chunk(1, 2, 3, 4, 5, 2, 3, 6).indexWhere(_ % 2 === 0, 1) <-> 1,
+        Remote.chunk(1, 2, 3, 4, 5, 2, 3, 6).indexWhere(_ % 2 === 0, 2) <-> 3
+      ),
+      remoteTest("init")(
+        Remote.emptyChunk[Int].init failsWithRemoteFailure "List is empty",
+        Remote.chunk(1).init <-> Chunk.empty[Int],
+        Remote.chunk(1, 2, 3).init <-> Chunk(1, 2)
+      ),
+      remoteTest("inits")(
+        Remote.emptyChunk[Int].inits <-> Chunk(Chunk.empty[Int]),
+        Remote.chunk(1, 2, 3).inits <-> Chunk(Chunk(1, 2, 3), Chunk(1, 2), Chunk(1), Chunk())
+      ),
+      remoteTest("intersect")(
+        Remote.emptyChunk[Int].intersect(Remote.chunk(3, 4, 5, 6)) <-> Chunk.empty[Int],
+        Remote.chunk(1, 2, 3, 4).intersect(Remote.chunk(3, 4, 5, 6)) <-> Chunk(3, 4),
+        Remote.chunk(1, 2, 3, 4).intersect(Remote.emptyChunk[Int]) <-> Chunk.empty[Int]
+      ),
+      remoteTest("isDefinedAt")(
+        Remote.emptyChunk[Int].isDefinedAt(0) <-> false,
+        Remote.chunk(1, 2, 3).isDefinedAt(0) <-> true,
+        Remote.chunk(1, 2, 3).isDefinedAt(2) <-> true,
+        Remote.chunk(1, 2, 3).isDefinedAt(3) <-> false
+      ),
+      remoteTest("isEmpty")(
+        Remote.emptyChunk[Int].isEmpty <-> true,
+        Remote.chunk(1, 2, 3).isEmpty <-> false
+      ),
+      remoteTest("last")(
+        Remote.emptyChunk[Int].last failsWithRemoteFailure "List is empty",
+        Remote.chunk(1, 2, 3).last <-> 3
+      ),
+      remoteTest("lastIndexOf")(
+        Remote.emptyChunk[Int].lastIndexOf(3) <-> -1,
+        Remote.chunk(1, 2, 4, 4).lastIndexOf(3) <-> -1,
+        Remote.chunk(1, 2, 3, 4, 3, 4).lastIndexOf(3) <-> 4,
+        Remote.chunk(1, 2, 3, 4, 3, 4).lastIndexOf(3, 4) <-> 4,
+        Remote.chunk(1, 2, 3, 4, 3, 4).lastIndexOf(3, 3) <-> 2
+      ),
+      remoteTest("lastIndexOfSlice")(
+        Remote.emptyChunk[Int].lastIndexOfSlice(Remote.chunk(3, 4)) <-> -1,
+        Remote.chunk(1, 2, 4, 4).lastIndexOfSlice(Remote.chunk(3, 4)) <-> -1,
+        Remote.chunk(1, 2, 3, 4, 3, 4).lastIndexOfSlice(Remote.chunk(3, 4)) <-> 4,
+        Remote.chunk(1, 2, 3, 4, 3, 4).lastIndexOfSlice(Remote.chunk(3, 4), 5) <-> 4,
+        Remote.chunk(1, 2, 3, 4, 3, 4).lastIndexOfSlice(Remote.chunk(3, 4), 3) <-> 2
+      ),
+      remoteTest("lastIndexWhere")(
+        Remote.emptyChunk[Int].lastIndexWhere(_ % 2 === 0) <-> -1,
+        Remote.chunk(1, 2, 3, 4, 5, 2, 3, 6).lastIndexWhere(_ % 2 === 0) <-> 7,
+        Remote.chunk(1, 2, 3, 4, 5, 2, 3, 6).lastIndexWhere(_ % 2 === 0, 6) <-> 5
+      ),
+      remoteTest("lastOption")(
+        Remote.emptyChunk[Int].lastOption <-> None,
+        Remote.chunk(1, 2, 3).lastOption <-> Some(3)
+      ),
+      remoteTest("length")(
+        Remote.emptyChunk[Int].length <-> 0,
+        Remote.chunk(1, 2, 3).length <-> 3
+      ),
+      remoteTest("map")(
+        Remote.emptyChunk[Int].map(_ * 2) <-> Chunk.empty[Int],
+        Remote.chunk(1, 2, 3).map(_ * 2) <-> Chunk(2, 4, 6)
+      ),
+      remoteTest("max")(
+        Remote.emptyChunk[Int].max failsWithRemoteFailure "List is empty",
+        Remote.chunk(1, 6, 4, 3, 8, 0, 4).max <-> 8
+      ),
+      remoteTest("maxBy")(
+        Remote.emptyChunk[String].maxBy(_.length) failsWithRemoteFailure "List is empty",
+        Remote.chunk("aaa", "a", "abcd", "ab").maxBy(_.length) <-> "abcd"
+      ),
+      remoteTest("maxByOption")(
+        Remote.emptyChunk[String].maxByOption(_.length) <-> None,
+        Remote.chunk("aaa", "a", "abcd", "ab").maxByOption(_.length) <-> Some("abcd")
+      ),
+      remoteTest("maxOption")(
+        Remote.emptyChunk[Int].maxOption <-> None,
+        Remote.chunk(1, 6, 4, 3, 8, 0, 4).maxOption <-> Some(8)
+      ),
+      remoteTest("min")(
+        Remote.emptyChunk[Int].min failsWithRemoteFailure "List is empty",
+        Remote.chunk(1, 6, 4, 3, 8, 0, 4).min <-> 0
+      ),
+      remoteTest("minBy")(
+        Remote.emptyChunk[String].minBy(_.length) failsWithRemoteFailure "List is empty",
+        Remote.chunk("aaa", "a", "abcd", "ab").minBy(_.length) <-> "a"
+      ),
+      remoteTest("minByOption")(
+        Remote.emptyChunk[String].minByOption(_.length) <-> None,
+        Remote.chunk("aaa", "a", "abcd", "ab").minByOption(_.length) <-> Some("a")
+      ),
+      remoteTest("minOption")(
+        Remote.emptyChunk[Int].minOption <-> None,
+        Remote.chunk(1, 6, 4, 3, 8, 0, 4).minOption <-> Some(0)
+      ),
+      remoteTest("mkString")(
+        Remote.emptyChunk[String].mkString <-> "",
+        Remote.chunk("hello", "world", "!!!").mkString <-> "helloworld!!!",
+        Remote.emptyChunk[Int].mkString <-> "",
+        Remote.chunk(1, 2, 3).mkString <-> "123",
+        Remote.chunk("hello", "world", "!!!").mkString("--") <-> "hello--world--!!!",
+        Remote.chunk(1, 2, 3).mkString("/") <-> "1/2/3",
+        Remote.chunk("hello", "world", "!!!").mkString("<", " ", ">") <-> "<hello world !!!>",
+        Remote.chunk(1, 2, 3).mkString("(", ", ", ")") <-> "(1, 2, 3)"
+      ),
+      remoteTest("nonEmpty")(
+        Remote.emptyChunk[Int].nonEmpty <-> false,
+        Remote.chunk(1, 2, 3).nonEmpty <-> true
+      ),
+      remoteTest("padTo")(
+        Remote.emptyChunk[Int].padTo(3, 11) <-> Chunk(11, 11, 11),
+        Remote.chunk(1, 2, 3).padTo(5, 11) <-> Chunk(1, 2, 3, 11, 11),
+        Remote.chunk(1, 2, 3).padTo(3, 11) <-> Chunk(1, 2, 3)
+      ),
+      remoteTest("partition")(
+        Remote.emptyChunk[Int].partition(_ % 2 === 0) <-> ((Chunk.empty[Int], Chunk.empty[Int])),
+        Remote.chunk(1, 2, 3, 4, 5).partition(_ % 2 === 0) <-> ((Chunk(2, 4), Chunk(1, 3, 5)))
+      ),
+      remoteTest("partitionMap")(
+        Remote
+          .emptyChunk[Int]
+          .partitionMap((n: Remote[Int]) =>
+            (n % 2 === 0).ifThenElse(ifTrue = Remote.left(n), ifFalse = Remote.right(n.toString))
+          ) <-> ((Chunk.empty[Int], Chunk.empty[String])),
+        Remote
+          .chunk(1, 2, 3, 4, 5)
+          .partitionMap((n: Remote[Int]) =>
+            (n % 2 === 0).ifThenElse(ifTrue = Remote.left(n), ifFalse = Remote.right(n.toString))
+          ) <-> ((Chunk(2, 4), Chunk("1", "3", "5")))
+      ),
+      remoteTest("patch")(
+        Remote.emptyChunk[Int].patch(0, Remote.emptyChunk[Int], 0) <-> Chunk.empty[Int],
+        Remote.emptyChunk[Int].patch(0, Remote.chunk(1, 2, 3), 2) <-> Chunk(1, 2, 3),
+        Remote.chunk(1, 2, 3, 4).patch(0, Remote.chunk(5, 6, 7), 2) <-> Chunk(5, 6, 7, 3, 4),
+        Remote.chunk(1, 2, 3, 4).patch(2, Remote.chunk(5, 6, 7), 1) <-> Chunk(1, 2, 5, 6, 7, 4)
+      ),
+      remoteTest("permutations")(
+        Remote.emptyChunk[Int].permutations <-> Chunk(Chunk.empty[Int]),
+        Remote.chunk(1, 2, 3).permutations <-> Chunk(
+          Chunk(1, 2, 3),
+          Chunk(1, 3, 2),
+          Chunk(2, 1, 3),
+          Chunk(2, 3, 1),
+          Chunk(3, 1, 2),
+          Chunk(3, 2, 1)
+        )
+      ),
+      remoteTest("prepended")(
+        Remote.emptyChunk[Int].prepended(1) <-> Chunk(1),
+        Remote.chunk(2, 3).prepended(1) <-> Chunk(1, 2, 3)
+      ),
+      remoteTest("prependedAll")(
+        Remote.emptyChunk[Int].prependedAll(Remote.chunk(1, 2)) <-> Chunk(1, 2),
+        Remote.chunk(2, 3).prependedAll(Remote.chunk(0, 1)) <-> Chunk(0, 1, 2, 3)
+      ),
+      remoteTest("product")(
+        Remote.emptyChunk[Int].product <-> 1,
+        Remote.chunk(1.0, 2.0, 3.0).product <-> 6.0
+      ),
+      remoteTest("reduce")(
+        Remote.emptyChunk[Int].reduce(_ + _) failsWithRemoteFailure "List is empty",
+        Remote.chunk(1, 2, 3).reduce(_ + _) <-> 6
+      ),
+      remoteTest("reduceLeft")(
+        Remote.emptyChunk[Int].reduceLeft(_ + _) failsWithRemoteFailure "List is empty",
+        Remote.chunk(1, 2, 3).reduceLeft(_ + _) <-> 6
+      ),
+      remoteTest("reduceLeftOption")(
+        Remote.emptyChunk[Int].reduceLeftOption(_ + _) <-> None,
+        Remote.chunk(1, 2, 3).reduceLeftOption(_ + _) <-> Some(6)
+      ),
+      remoteTest("reduceOption")(
+        Remote.emptyChunk[Int].reduceOption(_ + _) <-> None,
+        Remote.chunk(1, 2, 3).reduceOption(_ + _) <-> Some(6)
+      ),
+      remoteTest("reduceRight")(
+        Remote.emptyChunk[Int].reduceRight(_ + _) failsWithRemoteFailure "List is empty",
+        Remote.chunk(1.0, 2.0, 3.0).reduceRight(_ / _) <-> 1.5
+      ),
+      remoteTest("reduceRightOption")(
+        Remote.emptyChunk[Int].reduceRightOption(_ + _) <-> None,
+        Remote.chunk(1.0, 2.0, 3.0).reduceRightOption(_ / _) <-> Some(1.5)
+      ),
+      remoteTest("reverse")(
+        Remote.emptyChunk[Int].reverse <-> Chunk.empty[Int],
+        Remote.chunk(1).reverse <-> Chunk(1),
+        Remote.chunk(1, 2, 3).reverse <-> Chunk(3, 2, 1)
+      ),
+      remoteTest("sameElements")(
+        Remote.emptyChunk[Int].sameElements(Remote.emptyChunk[Int]) <-> true,
+        Remote.emptyChunk[Int].sameElements(Remote.chunk(1, 2, 3)) <-> false,
+        Remote.chunk(1, 2, 3, 4).sameElements(Remote.chunk(1, 2, 3)) <-> false,
+        Remote.chunk(1, 2).sameElements(Remote.chunk(1, 2, 3)) <-> false,
+        Remote.chunk(1, 2, 3).sameElements(Remote.chunk(1, 2, 3)) <-> true
+      ),
+      remoteTest("scan")(
+        Remote.emptyChunk[Int].scan(100)(_ / _) <-> Chunk(100),
+        Remote.chunk(1, 2, 3).scan(100)(_ / _) <-> Chunk(100, 100, 50, 16)
+      ),
+      remoteTest("scanLeft")(
+        Remote.emptyChunk[Int].scan(100)(_ / _) <-> Chunk(100),
+        Remote.chunk(1, 2, 3).scan(100)(_ / _) <-> Chunk(100, 100, 50, 16)
+      ),
+      remoteTest("scanRight")(
+        Remote.emptyChunk[Int].scanRight(100)(_ / _) <-> Chunk(100),
+        Remote.chunk(1.0, 2.0, 3.0).scanRight(100.0)(_ / _) <-> Chunk(0.015, 66.66666666666667, 0.03, 100.0)
+      ),
+      remoteTest("segmentLength")(
+        Remote.emptyChunk[Int].segmentLength(_ === 0) <-> 0,
+        Remote.chunk(1, 2, 3, 0, 0).segmentLength(_ === 0) <-> 0,
+        Remote.chunk(0, 0, 1, 2, 3).segmentLength(_ === 0) <-> 2,
+        Remote.chunk(0, 0, 1, 2, 3, 0, 0, 0).segmentLength(_ === 0, 3) <-> 0,
+        Remote.chunk(0, 0, 1, 2, 3, 0, 0, 0).segmentLength(_ === 0, 5) <-> 3
+      ),
+      remoteTest("size")(
+        Remote.emptyChunk[Int].size <-> 0,
+        Remote.chunk(1, 2, 3).size <-> 3
+      ),
+      remoteTest("slice")(
+        Remote.emptyChunk[Int].slice(2, 3) <-> Chunk.empty[Int],
+        Remote.chunk(1, 2, 3, 4, 5, 6).slice(2, 3) <-> Chunk(3),
+        Remote.chunk(1, 2, 3, 4, 5, 6).slice(2, 4) <-> Chunk(3, 4)
+      ),
+      remoteTest("sliding")(
+        Remote.emptyChunk[Int].sliding(1, 1) <-> Chunk.empty[Chunk[Int]],
+        Remote.chunk(0, 1, 2, 3, 3, 2, 3, 3, 3, 4, 5).sliding(1, 1) <-> Chunk(
+          Chunk(0),
+          Chunk(1),
+          Chunk(2),
+          Chunk(3),
+          Chunk(3),
+          Chunk(2),
+          Chunk(3),
+          Chunk(3),
+          Chunk(3),
+          Chunk(4),
+          Chunk(5)
+        ),
+        Remote.chunk(0, 1, 2, 3, 3, 2, 3, 3, 3, 4, 5).sliding(1, 2) <-> Chunk(
+          Chunk(0),
+          Chunk(2),
+          Chunk(3),
+          Chunk(3),
+          Chunk(3),
+          Chunk(5)
+        ),
+        Remote.chunk(0, 1, 2, 3, 3, 2, 3, 3, 3, 4, 5).sliding(3, 1) <-> Chunk(
+          Chunk(0, 1, 2),
+          Chunk(1, 2, 3),
+          Chunk(2, 3, 3),
+          Chunk(3, 3, 2),
+          Chunk(3, 2, 3),
+          Chunk(2, 3, 3),
+          Chunk(3, 3, 3),
+          Chunk(3, 3, 4),
+          Chunk(3, 4, 5)
+        )
+      ),
+      remoteTest("span")(
+        Remote.emptyChunk[Int].span(_ < 3) <-> ((Chunk.empty[Int], Chunk.empty[Int])),
+        Remote.chunk(1, 2, 3, 4, 5).span(_ < 3) <-> ((Chunk(1, 2), Chunk(3, 4, 5)))
+      ),
+      remoteTest("splitAt")(
+        Remote.emptyChunk[Int].splitAt(3) <-> ((Chunk.empty[Int], Chunk.empty[Int])),
+        Remote.chunk(1, 2, 3, 4, 5).splitAt(3) <-> ((Chunk(1, 2, 3), Chunk(4, 5))),
+        Remote.chunk(1, 2, 3, 4, 5).splitAt(0) <-> ((Chunk.empty, Chunk(1, 2, 3, 4, 5))),
+        Remote.chunk(1, 2, 3, 4, 5).splitAt(6) <-> ((Chunk(1, 2, 3, 4, 5), Chunk.empty))
+      ),
+//      remoteTest("startsWith")(
+//        Remote.emptyChunk[Int].startsWith(Remote.chunk(1, 2)) <-> false,
+//        Remote.chunk(1, 2, 3).startsWith(Remote.chunk(1, 2)) <-> true,
+//        Remote.chunk(0, 0, 1, 2).startsWith(Remote.chunk(1, 2)) <-> false
+//      ),
+      remoteTest("sum")(
+        Remote.emptyChunk[Int].sum <-> 0,
+        Remote.chunk(1, 2, 3, 4).sum <-> (1 + 2 + 3 + 4)
+      ),
+      remoteTest("tail")(
+        Remote.emptyChunk[Int].tail failsWithRemoteFailure "List is empty",
+        Remote.chunk(1).tail <-> Chunk.empty[Int],
+        Remote.chunk(1, 2, 3).tail <-> Chunk(2, 3)
+      ),
+      remoteTest("tails")(
+        Remote.emptyChunk[Int].tails <-> Chunk(Chunk.empty[Int]),
+        Remote.chunk(1, 2, 3).tails <-> Chunk(Chunk(1, 2, 3), Chunk(2, 3), Chunk(3), Chunk())
+      ),
+      remoteTest("take")(
+        Remote.emptyChunk[Int].take(2) <-> Chunk.empty[Int],
+        Remote.chunk(1, 2, 3, 4).take(2) <-> Chunk(1, 2)
+      ),
+      remoteTest("takeRight")(
+        Remote.emptyChunk[Int].takeRight(2) <-> Chunk.empty[Int],
+        Remote.chunk(1, 2, 3, 4).takeRight(2) <-> Chunk(3, 4)
+      ),
+      remoteTest("takeWhile")(
+        Remote.emptyChunk[Int].takeWhile(_ < 3) <-> Chunk.empty[Int],
+        Remote.chunk(1, 2, 3, 4).takeWhile(_ < 3) <-> Chunk(1, 2)
+      ),
+      remoteTest("toList")(
+        Remote.chunk(1, 2, 3).toList <-> List(1, 2, 3)
+      ),
+      remoteTest("toSet")(
+        Remote.chunk(1, 2, 3, 3, 2, 1).toSet <-> Set(1, 2, 3)
+      ),
+      remoteTest("unzip")(
+        Remote.emptyChunk[(Int, String)].unzip[Int, String] <-> ((Chunk.empty[Int], Chunk.empty[String])),
+        Remote.chunk((1, "x"), (2, "y"), (3, "z")).unzip[Int, String] <-> ((Chunk(1, 2, 3), Chunk("x", "y", "z")))
+      ),
+      remoteTest("unzip3")(
+        Remote
+          .emptyChunk[(Int, String, Double)]
+          .unzip3[Int, String, Double] <-> ((Chunk.empty[Int], Chunk.empty[String], Chunk.empty[Double])),
+        Remote
+          .chunk((1, "x", 0.1), (2, "y", 0.2), (3, "z", 0.3))
+          .unzip3[Int, String, Double] <-> ((Chunk(1, 2, 3), Chunk("x", "y", "z"), Chunk(0.1, 0.2, 0.3)))
+      ),
+      remoteTest("zip")(
+        Remote.emptyChunk[Int].zip(Remote.emptyChunk[String]) <-> Chunk.empty[(Int, String)],
+        Remote.emptyChunk[Int].zip(Remote.chunk("x", "y")) <-> Chunk.empty[(Int, String)],
+        Remote.chunk(1, 2).zip(Remote.emptyChunk[String]) <-> Chunk.empty[(Int, String)],
+        Remote.chunk(1, 2).zip(Remote.chunk("x", "y")) <-> Chunk((1, "x"), (2, "y")),
+        Remote.chunk(1, 2, 3).zip(Remote.chunk("x", "y")) <-> Chunk((1, "x"), (2, "y")),
+        Remote.chunk(1, 2).zip(Remote.chunk("x", "y", "z")) <-> Chunk((1, "x"), (2, "y"))
+      ),
+      remoteTest("zipAll")(
+        Remote.emptyChunk[Int].zipAll(Remote.emptyChunk[String], -1, "-") <-> Chunk.empty[(Int, String)],
+        Remote.emptyChunk[Int].zipAll(Remote.chunk("x", "y"), -1, "-") <-> Chunk((-1, "x"), (-1, "y")),
+        Remote.chunk(1, 2).zipAll(Remote.emptyChunk[String], -1, "-") <-> Chunk((1, "-"), (2, "-")),
+        Remote.chunk(1, 2).zipAll(Remote.chunk("x", "y"), -1, "-") <-> Chunk((1, "x"), (2, "y")),
+        Remote.chunk(1, 2, 3).zipAll(Remote.chunk("x", "y"), -1, "-") <-> Chunk((1, "x"), (2, "y"), (3, "-")),
+        Remote.chunk(1, 2).zipAll(Remote.chunk("x", "y", "z"), -1, "-") <-> Chunk((1, "x"), (2, "y"), (-1, "z"))
+      ),
+      remoteTest("zipWithIndex")(
+        Remote.emptyChunk[String].zipWithIndex <-> Chunk.empty[(String, Int)],
+        Remote.chunk("a", "b", "c").zipWithIndex <-> Chunk("a" -> 0, "b" -> 1, "c" -> 2)
+      ),
+      remoteTest("chunk.fill")(
+        Chunk.fill(Remote(3))(Remote(1)) <-> Chunk(1, 1, 1)
+      )
+    ).provide(ZLayer(InMemoryRemoteContext.make), LocalContext.inMemory)
+}

--- a/zio-flow-runtime/src/test/scala/zio/flow/remote/RemoteListSyntaxSpec.scala
+++ b/zio-flow-runtime/src/test/scala/zio/flow/remote/RemoteListSyntaxSpec.scala
@@ -69,8 +69,8 @@ object RemoteListSyntaxSpec extends RemoteSpecBase {
         Remote.nil[Int] ::: Remote.nil[Int] <-> List.empty
       ),
       remoteTest("appended")(
-        Remote.nil[Int] :+ Remote(1) <-> List(1),
-        Remote.list(2, 3) :+ Remote(1) <-> List(2, 3, 1)
+        Remote.nil[Int].appended(Remote(1)) <-> List(1),
+        Remote.list(2, 3).appended(Remote(1)) <-> List(2, 3, 1)
       ),
       remoteTest("appendedAll")(
         Remote.list(1, 2, 3, 4).appendedAll(Remote.list(5, 6, 7)) <-> List(1, 2, 3, 4, 5, 6, 7),
@@ -432,8 +432,8 @@ object RemoteListSyntaxSpec extends RemoteSpecBase {
         Remote.list(0, 0, 1, 2, 3, 0, 0, 0).segmentLength(_ === 0, 5) <-> 3
       ),
       remoteTest("size")(
-        Remote.nil[Int].length <-> 0,
-        Remote.list(1, 2, 3).length <-> 3
+        Remote.nil[Int].size <-> 0,
+        Remote.list(1, 2, 3).size <-> 3
       ),
       remoteTest("slice")(
         Remote.nil[Int].slice(2, 3) <-> List.empty[Int],

--- a/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/Remote.scala
@@ -3057,8 +3057,13 @@ object Remote {
     Bind(unbound, value, f(unbound))
   }
 
+  def chunk[A](values: Remote[A]*): Remote[Chunk[A]] =
+    Chunk.fromList(list(values: _*))
+
   def config[A: Schema](key: ConfigKey): Remote[A] =
     Config(key, implicitly[Schema[A]])
+
+  def emptyChunk[A]: Remote[Chunk[A]] = Remote.Literal(DynamicValue.Sequence(Chunk.empty))
 
   def fail[A](message: String): Remote[A] =
     Remote.Fail(message)

--- a/zio-flow/shared/src/main/scala/zio/flow/Syntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/Syntax.scala
@@ -16,7 +16,7 @@
 
 package zio.flow
 
-import zio.Duration
+import zio.{Chunk, Duration}
 import zio.flow.remote._
 import zio.flow.remote.RemoteTuples._
 
@@ -285,4 +285,11 @@ trait Syntax {
   implicit class ZFlowSyntax[R, E, A](flow: ZFlow[R, E, A]) {
     def toRemote: Remote.Flow[R, E, A] = Remote.Flow(flow)
   }
+
+  implicit def RemoteChunk[A](remote: Remote[Chunk[A]]): RemoteChunkSyntax[A] =
+    new RemoteChunkSyntax[A](remote, trackingEnabled = false)
+
+  implicit def RemoteChunkCompanion(chunk: Chunk.type): RemoteChunkCompanionSyntax = new RemoteChunkCompanionSyntax(
+    chunk
+  )
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/debug/TrackRemotes.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/debug/TrackRemotes.scala
@@ -16,7 +16,8 @@
 
 package zio.flow.debug
 
-import zio.flow.remote.{InternalRemoteTracking, RemoteListSyntax, RemoteStringSyntax}
+import zio.Chunk
+import zio.flow.remote.{InternalRemoteTracking, RemoteChunkSyntax, RemoteListSyntax, RemoteStringSyntax}
 import zio.flow.{Remote, Syntax}
 
 import scala.language.implicitConversions
@@ -28,6 +29,9 @@ object TrackRemotes extends Syntax {
 
   override implicit def RemoteString(remote: Remote[String]): RemoteStringSyntax =
     new RemoteStringSyntax(remote, trackingEnabled = true)
+
+  override implicit def RemoteChunk[A](remote: Remote[Chunk[A]]): RemoteChunkSyntax[A] =
+    new RemoteChunkSyntax[A](remote, trackingEnabled = true)
 
   def ifEnabled(implicit remoteTracking: InternalRemoteTracking): Syntax =
     if (remoteTracking.enabled)

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteAccessorBuilder.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteAccessorBuilder.scala
@@ -29,12 +29,15 @@ object RemoteAccessorBuilder extends AccessorBuilder {
   override type Prism[F, S, A]  = RemoteOptic.Prism[F, S, A]
   override type Traversal[S, A] = RemoteOptic.Traversal[S, A]
 
-  override def makeLens[F, S, A](product: Schema.Record[S], term: Schema.Field[A]): Lens[F, S, A] =
+  override def makeLens[F, S, A](product: Schema.Record[S], term: Schema.Field[A]): RemoteOptic.Lens[F, S, A] =
     RemoteOptic.Lens(term.label)
 
-  override def makePrism[F, S, A](sum: Schema.Enum[S], term: Schema.Case[A, S]): Prism[F, S, A] =
+  override def makePrism[F, S, A](sum: Schema.Enum[S], term: Schema.Case[A, S]): RemoteOptic.Prism[F, S, A] =
     RemoteOptic.Prism(sum.id, term.id)
 
-  override def makeTraversal[S, A](collection: Schema.Collection[S, A], element: Schema[A]): Traversal[S, A] =
+  override def makeTraversal[S, A](
+    collection: Schema.Collection[S, A],
+    element: Schema[A]
+  ): RemoteOptic.Traversal[S, A] =
     RemoteOptic.Traversal()
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteChunkCompanionSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteChunkCompanionSyntax.scala
@@ -17,17 +17,15 @@
 package zio.flow.remote
 
 import zio.flow._
+import zio.Chunk
 
-final class RemoteListCompanionSyntax(val self: List.type) extends AnyVal {
-  def fill[A](n: Remote[Int])(elem: Remote[A]): Remote[List[A]] =
-    Remote
-      .recurseSimple((n, Remote.nil[A])) { case (input, rec) =>
-        val current = input._1
-        val lst     = input._2
-        (current === 0).ifThenElse(
-          ifTrue = (current, lst),
-          ifFalse = rec((current - 1, elem :: lst))
-        )
-      }
-      ._2
+final class RemoteChunkCompanionSyntax(val self: Chunk.type) extends AnyVal {
+  def fill[A](n: Remote[Int])(elem: Remote[A]): Remote[Chunk[A]] =
+    fromList(List.fill(n)(elem))
+
+  def fromList[A](list: Remote[List[A]]): Remote[Chunk[A]] =
+    // NOTE: We take advantage of the fact that List and Chunk are represented the same on the DynamicValue level.
+    //       A safer implementation in the future would use RemoteOptic.Traversal to convert from/to lists but that
+    //       is currently broken.
+    list.asInstanceOf[Remote[Chunk[A]]]
 }

--- a/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteChunkSyntax.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/remote/RemoteChunkSyntax.scala
@@ -1,0 +1,387 @@
+/*
+ * Copyright 2021-2022 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.flow.remote
+
+import zio.Chunk
+import zio.flow._
+import zio.flow.debug.TrackRemotes
+import zio.flow.remote.numeric._
+import zio.schema.Schema
+
+final class RemoteChunkSyntax[A](val self: Remote[Chunk[A]], trackingEnabled: Boolean) {
+  implicit private val remoteTracking: InternalRemoteTracking = InternalRemoteTracking(trackingEnabled)
+  private val syntax                                          = TrackRemotes.ifEnabled
+  import syntax._
+
+  def ++[B >: A](that: Remote[Chunk[B]]): Remote[Chunk[B]] =
+    concat(that).trackInternal("Chunk#++")
+
+  def ++:(prefix: Remote[Chunk[A]]): Remote[Chunk[A]] =
+    Chunk.fromList(prefix.toList ++: self.toList).trackInternal("Chunk#++:")
+
+  def +:[B >: A](elem: Remote[B]): Remote[Chunk[B]] =
+    Chunk.fromList(elem +: self.toList).trackInternal("Chunk#+:")
+
+  def :+[B >: A](elem: Remote[B]): Remote[Chunk[B]] =
+    Chunk.fromList(self.toList :+ elem).trackInternal("Chunk#:+")
+
+  def :++[B >: A](suffix: Remote[Chunk[B]]): Remote[Chunk[B]] =
+    Chunk.fromList(self.toList :++ suffix.toList).trackInternal("Chunk#:++")
+
+  def appended[B >: A](elem: Remote[B]): Remote[Chunk[B]] =
+    self :+ elem
+
+  def appendedAll[B >: A](suffix: Remote[Chunk[B]]): Remote[Chunk[B]] =
+    self :++ suffix
+
+  def apply(index: Remote[Int]): Remote[A] =
+    toList.apply(index).trackInternal("Chunk#apply")
+
+  def concat[B >: A](that: Remote[Chunk[B]]): Remote[Chunk[B]] =
+    Chunk.fromList(toList.concat(that.toList)).trackInternal("Chunk#concat")
+
+  def contains(elem: Remote[A]): Remote[Boolean] =
+    toList.contains(elem).trackInternal("Chunk#contains")
+
+  def containsSlice[B >: A](that: Remote[Chunk[B]]): Remote[Boolean] =
+    toList.containsSlice(that.toList).trackInternal("Chunk#containsSlice")
+
+  def corresponds[B](that: Remote[Chunk[B]])(p: (Remote[A], Remote[B]) => Remote[Boolean]): Remote[Boolean] =
+    toList.corresponds(that.toList)(p).trackInternal("Chunk#corresponds")
+
+  def count(p: Remote[A] => Remote[Boolean]): Remote[Int] =
+    toList.count(p).trackInternal("Chunk#count")
+
+  def diff(that: Remote[Chunk[A]]): Remote[Chunk[A]] =
+    Chunk.fromList(toList.diff(that.toList)).trackInternal("Chunk#diff")
+
+  def distinct: Remote[Chunk[A]] =
+    Chunk.fromList(self.toList.distinct).trackInternal("Chunk#distinct")
+
+  def distinctBy[B](f: Remote[A] => Remote[B]): Remote[Chunk[A]] =
+    Chunk.fromList(self.toList.distinctBy(f)).trackInternal("Chunk#distinctBy")
+
+  def drop(n: Remote[Int]): Remote[Chunk[A]] =
+    Chunk.fromList(toList.drop(n)).trackInternal("Chunk#drop")
+
+  def dropRight(n: Remote[Int]): Remote[Chunk[A]] =
+    Chunk.fromList(toList.dropRight(n)).trackInternal("Chunk#dropRight")
+
+  def dropWhile(predicate: Remote[A] => Remote[Boolean]): Remote[Chunk[A]] =
+    Chunk.fromList(toList.dropWhile(predicate)).trackInternal("Chunk#dropWhile")
+
+  def endsWith[B >: A](that: Remote[Chunk[B]]): Remote[Boolean] =
+    self.toList.endsWith(that.toList).trackInternal("Chunk#endsWith")
+
+  def empty: Remote[Chunk[A]] =
+    Remote.emptyChunk[A].trackInternal("Chunk#empty")
+
+  def exists(p: Remote[A] => Remote[Boolean]): Remote[Boolean] =
+    toList.exists(p).trackInternal("Chunk#exists")
+
+  def filter(
+    predicate: Remote[A] => Remote[Boolean]
+  ): Remote[Chunk[A]] =
+    Chunk.fromList(toList.filter(predicate)).trackInternal("Chunk#filter")
+
+  def filterNot(
+    predicate: Remote[A] => Remote[Boolean]
+  ): Remote[Chunk[A]] =
+    Chunk.fromList(toList.filterNot(predicate)).trackInternal("Chunk#filterNot")
+
+  def find(p: Remote[A] => Remote[Boolean]): Remote[Option[A]] =
+    toList.find(p).trackInternal("Chunk#find")
+
+  def findLast(p: Remote[A] => Remote[Boolean]): Remote[Option[A]] =
+    toList.findLast(p).trackInternal("Chunk#findLast")
+
+  def flatMap[B](f: Remote[A] => Remote[Chunk[B]]): Remote[Chunk[B]] =
+    Chunk.fromList(toList.flatMap(f(_).toList)).trackInternal("Chunk#flatMap")
+
+  def flatten[B](implicit ev: A <:< Chunk[B]): Remote[Chunk[B]] =
+    Chunk.fromList(toList.map(a => a.widen[Chunk[B]].toList).flatten).trackInternal("Chunk#flatten")
+
+  def fold[B](initial: Remote[B])(
+    f: (Remote[B], Remote[A]) => Remote[B]
+  ): Remote[B] =
+    toList.fold(initial)(f).trackInternal("Chunk#fold")
+
+  def foldLeft[B](initial: Remote[B])(
+    f: (Remote[B], Remote[A]) => Remote[B]
+  ): Remote[B] =
+    toList.foldLeft(initial)(f).trackInternal("Chunk#foldLeft")
+
+  def foldRight[B](initial: Remote[B])(
+    f: (Remote[A], Remote[B]) => Remote[B]
+  ): Remote[B] =
+    toList.foldRight(initial)(f).trackInternal("Chunk#foldRight")
+
+  def forall(p: Remote[A] => Remote[Boolean]): Remote[Boolean] =
+    toList.forall(p).trackInternal("Chunk#forall")
+
+  // TODO: groupBy etc if we have support for Remote[Map[K, V]]
+
+  def head: Remote[A] =
+    toList.head.trackInternal("Chunk#head")
+
+  def headOption: Remote[Option[A]] =
+    toList.headOption.trackInternal("Chunk#headOption")
+
+  def indexOf[B >: A](elem: Remote[B]): Remote[Int] =
+    toList.indexOf(elem).trackInternal("Chunk#indexOf")
+
+  def indexOf[B >: A](elem: Remote[B], from: Remote[Int]): Remote[Int] =
+    toList.indexOf(elem, from).trackInternal("Chunk#indexOf")
+
+  def indexOfSlice[B >: A](that: Remote[Chunk[B]]): Remote[Int] =
+    toList.indexOfSlice(that.toList).trackInternal("Chunk#indexOfSlice")
+
+  def indexOfSlice[B >: A](that: Remote[Chunk[B]], from: Remote[Int]): Remote[Int] =
+    toList.indexOfSlice(that.toList, from).trackInternal("Chunk#indexOfSlice")
+
+  def indexWhere(p: Remote[A] => Remote[Boolean]): Remote[Int] =
+    toList.indexWhere(p).trackInternal("Chunk#indexWhere")
+
+  def indexWhere(p: Remote[A] => Remote[Boolean], from: Remote[Int]): Remote[Int] =
+    toList.indexWhere(p, from).trackInternal("Chunk#indexWhere")
+
+  def init: Remote[Chunk[A]] =
+    Chunk.fromList(toList.init).trackInternal("Chunk#init")
+
+  def inits: Remote[Chunk[Chunk[A]]] =
+    Chunk.fromList(toList.inits.map(Chunk.fromList(_))).trackInternal("Chunk#inits")
+
+  def intersect(that: Remote[Chunk[A]]): Remote[Chunk[A]] =
+    Chunk.fromList(toList.intersect(that.toList)).trackInternal("Chunk#intersect")
+
+  def isDefinedAt(x: Remote[Int]): Remote[Boolean] =
+    self.toList.isDefinedAt(x).trackInternal("Chunk#isDefinedAt")
+
+  def isEmpty: Remote[Boolean] =
+    toList.isEmpty.trackInternal("Chunk#isEmpty")
+
+  def last: Remote[A] =
+    toList.last.trackInternal("Chunk#last")
+
+  def lastIndexOf[B >: A](elem: Remote[B]): Remote[Int] =
+    toList.lastIndexOf(elem).trackInternal("Chunk#lastIndexOf")
+
+  def lastIndexOf[B >: A](elem: Remote[B], from: Remote[Int]): Remote[Int] =
+    toList.lastIndexOf(elem, from).trackInternal("Chunk#lastIndexOf")
+
+  def lastIndexOfSlice[B >: A](that: Remote[Chunk[B]]): Remote[Int] =
+    toList.lastIndexOfSlice(that.toList).trackInternal("Chunk#lastIndexOfSlice")
+
+  def lastIndexOfSlice[B >: A](that: Remote[Chunk[B]], from: Remote[Int]): Remote[Int] =
+    toList.lastIndexOfSlice(that.toList, from).trackInternal("Chunk#lastIndexOfSlice")
+
+  def lastIndexWhere(p: Remote[A] => Remote[Boolean]): Remote[Int] =
+    toList.lastIndexWhere(p).trackInternal("Chunk#lastIndexWhere")
+
+  def lastIndexWhere(p: Remote[A] => Remote[Boolean], from: Remote[Int]): Remote[Int] =
+    toList.lastIndexWhere(p, from).trackInternal("Chunk#lastIndexWhere")
+
+  def lastOption: Remote[Option[A]] =
+    toList.lastOption.trackInternal("Chunk#lastOption")
+
+  def length: Remote[Int] =
+    toList.length.trackInternal("Chunk#length")
+
+  def map[B](f: Remote[A] => Remote[B]): Remote[Chunk[B]] =
+    Chunk.fromList(toList.map(f)).trackInternal("Chunk#map")
+
+  def max(implicit schema: Schema[A]): Remote[A] =
+    toList.max.trackInternal("Chunk#max")
+
+  def maxBy[B](f: Remote[A] => Remote[B])(implicit schema: Schema[B]): Remote[A] =
+    toList.maxBy(f).trackInternal("Chunk#maxBy")
+
+  def maxByOption[B](f: Remote[A] => Remote[B])(implicit schema: Schema[B]): Remote[Option[A]] =
+    toList.maxByOption(f).trackInternal("Chunk#maxByOption")
+
+  def maxOption(implicit schema: Schema[A]): Remote[Option[A]] =
+    toList.maxOption.trackInternal("Chunk#maxOption")
+
+  def min(implicit schema: Schema[A]): Remote[A] =
+    toList.min.trackInternal("Chunk#min")
+
+  def minBy[B](f: Remote[A] => Remote[B])(implicit schema: Schema[B]): Remote[A] =
+    toList.minBy(f).trackInternal("Chunk#minBy")
+
+  def minByOption[B](f: Remote[A] => Remote[B])(implicit schema: Schema[B]): Remote[Option[A]] =
+    toList.minByOption(f).trackInternal("Chunk#minByOption")
+
+  def minOption(implicit schema: Schema[A]): Remote[Option[A]] =
+    toList.minOption.trackInternal("Chunk#minOption")
+
+  def mkString(implicit schema: Schema[A]): Remote[String] =
+    toList.mkString.trackInternal("Chunk#mkString")
+
+  def mkString(sep: Remote[String])(implicit schema: Schema[A]): Remote[String] =
+    toList.mkString(sep).trackInternal("Chunk#mkString")
+
+  def mkString(start: Remote[String], sep: Remote[String], end: Remote[String])(implicit
+    schema: Schema[A]
+  ): Remote[String] =
+    toList.mkString(start, sep, end).trackInternal("Chunk#mkString")
+
+  def nonEmpty: Remote[Boolean] =
+    toList.nonEmpty.trackInternal("Chunk#nonEmpty")
+
+  def padTo[B >: A](len: Remote[Int], elem: Remote[B]): Remote[Chunk[B]] =
+    Chunk.fromList(self.toList.padTo(len, elem)).trackInternal("Chunk#padTo")
+
+  def partition(p: Remote[A] => Remote[Boolean]): Remote[(Chunk[A], Chunk[A])] =
+    Remote
+      .bind(toList.partition(p)) { tuple =>
+        (Chunk.fromList(tuple._1), Chunk.fromList(tuple._2))
+      }
+      .trackInternal("Chunk#partition")
+
+  def partitionMap[A1, A2](p: Remote[A] => Remote[Either[A1, A2]]): Remote[(Chunk[A1], Chunk[A2])] =
+    Remote
+      .bind(toList.partitionMap(p)) { tuple =>
+        (Chunk.fromList(tuple._1), Chunk.fromList(tuple._2))
+      }
+      .trackInternal("Chunk#partitionMap")
+
+  def patch[B >: A](from: Remote[Int], other: Remote[Chunk[B]], replaced: Remote[Int]): Remote[Chunk[B]] =
+    Chunk.fromList(toList.patch(from, other.toList, replaced)).trackInternal("Chunk#patch")
+
+  def permutations: Remote[Chunk[Chunk[A]]] =
+    Chunk.fromList(self.toList.permutations.map(Chunk.fromList(_))).trackInternal("Chunk#permutations")
+
+  def prepended[B >: A](elem: Remote[B]): Remote[Chunk[B]] =
+    Chunk.fromList(toList.prepended(elem)).trackInternal("Chunk#prepended")
+
+  def prependedAll[B >: A](prefix: Remote[Chunk[B]]): Remote[Chunk[B]] =
+    Chunk.fromList(toList.prependedAll(prefix.toList)).trackInternal("Chunk#prependedAll")
+
+  def product(implicit numeric: Numeric[A]): Remote[A] =
+    toList.product.trackInternal("Chunk#product")
+
+  def reduce[B >: A](op: (Remote[B], Remote[B]) => Remote[B]): Remote[B] =
+    toList.reduce(op).trackInternal("Chunk#reduce")
+
+  def reduceLeft[B >: A](op: (Remote[B], Remote[A]) => Remote[B]): Remote[B] =
+    toList.reduceLeft(op).trackInternal("Chunk#reduceLeft")
+
+  def reduceLeftOption[B >: A](op: (Remote[B], Remote[A]) => Remote[B]): Remote[Option[B]] =
+    toList.reduceLeftOption(op).trackInternal("Chunk#reduceLeftOption")
+
+  def reduceOption[B >: A](op: (Remote[B], Remote[B]) => Remote[B]): Remote[Option[B]] =
+    toList.reduceOption(op).trackInternal("Chunk#reduceOption")
+
+  def reduceRight[B >: A](op: (Remote[A], Remote[B]) => Remote[B]): Remote[B] =
+    toList.reduceRight(op).trackInternal("Chunk#reduceRight")
+
+  def reduceRightOption[B >: A](op: (Remote[A], Remote[B]) => Remote[B]): Remote[Option[B]] =
+    toList.reduceRightOption(op).trackInternal("Chunk#reduceRightOption")
+
+  def removedAll(that: Remote[Chunk[A]]): Remote[Chunk[A]] =
+    diff(Chunk.fromList(that.toList)).trackInternal("Chunk#removedAll")
+
+  def reverse: Remote[Chunk[A]] =
+    Chunk.fromList(toList.reverse).trackInternal("Chunk#reverse")
+
+  def sameElements[B >: A](other: Remote[Chunk[B]]): Remote[Boolean] =
+    toList.sameElements(other.toList).trackInternal("Chunk#sameElements")
+
+  def scan[B >: A](z: Remote[B])(op: (Remote[B], Remote[B]) => Remote[B]): Remote[Chunk[B]] =
+    Chunk.fromList(toList.scan(z)(op)).trackInternal("Chunk#scan")
+
+  def scanLeft[B >: A](z: Remote[B])(op: (Remote[B], Remote[A]) => Remote[B]): Remote[Chunk[B]] =
+    Chunk.fromList(toList.scanLeft(z)(op)).trackInternal("Chunk#scanLeft")
+
+  def scanRight[B >: A](z: Remote[B])(op: (Remote[A], Remote[B]) => Remote[B]): Remote[Chunk[B]] =
+    Chunk.fromList(toList.scanRight(z)(op)).trackInternal("Chunk#scanRight")
+
+  def segmentLength(p: Remote[A] => Remote[Boolean]): Remote[Int] =
+    toList.segmentLength(p).trackInternal("Chunk#segmentLength")
+
+  def segmentLength(p: Remote[A] => Remote[Boolean], from: Remote[Int]): Remote[Int] =
+    toList.segmentLength(p, from).trackInternal("Chunk#segmentLength")
+
+  def size: Remote[Int] =
+    toList.size.trackInternal("Chunk#size")
+
+  def slice(from: Remote[Int], until: Remote[Int]): Remote[Chunk[A]] =
+    Chunk.fromList(toList.slice(from, until)).trackInternal("Chunk#slice")
+
+  def sliding(size: Remote[Int], step: Remote[Int]): Remote[Chunk[Chunk[A]]] =
+    Chunk.fromList(toList.sliding(size, step).map(Chunk.fromList(_))).trackInternal("Chunk#sliding")
+
+  def sliding(size: Remote[Int]): Remote[Chunk[Chunk[A]]] =
+    sliding(size, 1)
+
+  def span(p: Remote[A] => Remote[Boolean]): Remote[(Chunk[A], Chunk[A])] =
+    Remote.bind(toList.span(p)) { tuple =>
+      (Chunk.fromList(tuple._1), Chunk.fromList(tuple._2)).trackInternal("Chunk#span")
+    }
+
+  def splitAt(n: Remote[Int]): Remote[(Chunk[A], Chunk[A])] =
+    Remote.bind(toList.splitAt(n)) { tuple =>
+      (Chunk.fromList(tuple._1), Chunk.fromList(tuple._2)).trackInternal("Chunk#splitAt")
+    }
+
+  def sum(implicit numeric: Numeric[A]): Remote[A] =
+    toList.sum.trackInternal("Chunk#sum")
+
+  def tail: Remote[Chunk[A]] =
+    Chunk.fromList(toList.tail).trackInternal("Chunk#tail")
+
+  def tails: Remote[Chunk[Chunk[A]]] =
+    Chunk.fromList(toList.tails.map(Chunk.fromList(_))).trackInternal("Chunk#tails")
+
+  def take(n: Remote[Int]): Remote[Chunk[A]] =
+    Chunk.fromList(toList.take(n)).trackInternal("Chunk#take")
+
+  def takeRight(n: Remote[Int]): Remote[Chunk[A]] =
+    Chunk.fromList(toList.takeRight(n)).trackInternal("Chunk#takeRight")
+
+  def takeWhile(p: Remote[A] => Remote[Boolean]): Remote[Chunk[A]] =
+    Chunk.fromList(toList.takeWhile(p)).trackInternal("Chunk#takeWhile")
+
+  def toList: Remote[List[A]] =
+    self.asInstanceOf[Remote[List[A]]].trackInternal("Chunk#toList")
+
+  def toSet: Remote[Set[A]] =
+    toList.toSet.trackInternal("Chunk#toSet")
+
+  def unzip[A1, A2](implicit ev: A =:= (A1, A2)): Remote[(Chunk[A1], Chunk[A2])] =
+    Remote
+      .bind(toList.unzip) { tuple =>
+        (Chunk.fromList(tuple._1), Chunk.fromList(tuple._2))
+      }
+      .trackInternal("Chunk#unzip")
+
+  def unzip3[A1, A2, A3](implicit ev: A =:= (A1, A2, A3)): Remote[(Chunk[A1], Chunk[A2], Chunk[A3])] =
+    Remote
+      .bind(toList.unzip3) { tuple =>
+        (Chunk.fromList(tuple._1), Chunk.fromList(tuple._2), Chunk.fromList(tuple._3))
+      }
+      .trackInternal("Chunk#unzip3")
+
+  def zip[B](that: Remote[Chunk[B]]): Remote[Chunk[(A, B)]] =
+    Chunk.fromList(toList.zip(that.toList)).trackInternal("Chunk#zip")
+
+  def zipAll[B](that: Remote[Chunk[B]], thisElem: Remote[A], thatElem: Remote[B]): Remote[Chunk[(A, B)]] =
+    Chunk.fromList(toList.zipAll(that.toList, thisElem, thatElem)).trackInternal("Chunk#zipALl")
+
+  def zipWithIndex: Remote[Chunk[(A, Int)]] =
+    Chunk.fromList(toList.zipWithIndex).trackInternal("Chunk#zipWithIndex")
+}


### PR DESCRIPTION
Resolves #106 

Just a `Remote[Chunk[A]]` syntax using the remote list implementations under the hood.

The common Seq/Iterable etc syntaxes could be possibly merged later if zio-schema's `Traversal` accessor would work but it does not typecheck right now (https://github.com/zio/zio-schema/issues/354).