### PR TITLE
Fix executor's variable tracking and improve logging

### DIFF
--- a/zio-flow-runtime/src/main/scala/zio/flow/runtime/internal/RemoteVariableKeyValueStore.scala
+++ b/zio-flow-runtime/src/main/scala/zio/flow/runtime/internal/RemoteVariableKeyValueStore.scala
@@ -90,7 +90,8 @@ final case class RemoteVariableKeyValueStore(
       .mapError(ExecutorError.KeyValueStoreError("getLatestTimestamp", _))
       .flatMap {
         case Some(value) =>
-          ZIO.some((value, scope))
+          ZIO.logTrace(s"Found latest timestamp of $name in scope $scope: $value") *>
+            ZIO.some((value, scope))
         case None =>
           scope.parentScope match {
             case Some(parentScope) =>

--- a/zio-flow-runtime/src/main/scala/zio/flow/runtime/internal/RemoteVariableScope.scala
+++ b/zio-flow-runtime/src/main/scala/zio/flow/runtime/internal/RemoteVariableScope.scala
@@ -105,7 +105,7 @@ sealed trait RemoteVariableScope {
   val transactionId: Option[TransactionId]
   val parentScope: Option[RemoteVariableScope]
 
-  def rootScope: RemoteVariableScope
+  def rootScope: RemoteVariableScope.TopLevel
 }
 
 object RemoteVariableScope {
@@ -115,7 +115,7 @@ object RemoteVariableScope {
     override val transactionId: Option[TransactionId]     = None
     override val parentScope: Option[RemoteVariableScope] = None
 
-    override def rootScope: RemoteVariableScope = this
+    override def rootScope: RemoteVariableScope.TopLevel = this
 
     override def toString: String = flowId.toString
   }
@@ -124,7 +124,7 @@ object RemoteVariableScope {
     override val transactionId: Option[TransactionId]     = None
     override val parentScope: Option[RemoteVariableScope] = Some(parent)
 
-    override def rootScope: RemoteVariableScope = parent.rootScope
+    override def rootScope: RemoteVariableScope.TopLevel = parent.rootScope
 
     override def toString: String =
       parent.toString + "/" + flowId.toString
@@ -135,7 +135,7 @@ object RemoteVariableScope {
     override val transactionId: Option[TransactionId]     = Some(transaction)
     override val parentScope: Option[RemoteVariableScope] = Some(parent)
 
-    override def rootScope: RemoteVariableScope = parent.rootScope
+    override def rootScope: RemoteVariableScope.TopLevel = parent.rootScope
 
     override def toString: String =
       parent.toString + ":" + transaction.toString

--- a/zio-flow-runtime/src/test/scala/zio/flow/runtime/internal/executor/PersistentExecutorSpec.scala
+++ b/zio-flow-runtime/src/test/scala/zio/flow/runtime/internal/executor/PersistentExecutorSpec.scala
@@ -247,25 +247,28 @@ object PersistentExecutorSpec extends PersistentExecutorBaseSpec {
         } { result =>
           assertTrue(result == Right(123))
         },
-        testFlow("conflicting change of shared variable in transaction", periodicAdjustClock = Some(500.millis)) {
+        testFlow(
+          "conflicting change of shared variable in transaction",
+          periodicAdjustClock = Some(500.millis),
+          maxCount = 300
+        ) {
           for {
             var1 <- ZFlow.newVar[Int]("var1", 10)
             var2 <- ZFlow.newVar[Int]("var2", 20)
-            now  <- ZFlow.now
             fib1 <- ZFlow.transaction { _ =>
                       for {
-                        _ <- ZFlow.waitTill(now.plusSeconds(1L))
+                        _ <- ZFlow.sleep(1.second)
                         _ <- var1.update(_ + 1)
-                        _ <- ZFlow.waitTill(now.plusSeconds(1L))
+                        _ <- ZFlow.sleep(1.second)
                         _ <- var2.update(_ + 1)
-                        _ <- ZFlow.waitTill(now.plusSeconds(1L))
+                        _ <- ZFlow.sleep(1.second)
                       } yield ()
                     }.fork
             fib2 <- ZFlow.transaction { _ =>
                       for {
-                        _ <- ZFlow.waitTill(now.plusSeconds(1L))
+                        _ <- ZFlow.sleep(1.second)
                         _ <- var1.update(_ + 1)
-                        _ <- ZFlow.waitTill(now.plusSeconds(1L))
+                        _ <- ZFlow.sleep(1.second)
                         _ <- var2.update(_ + 1)
                       } yield ()
                     }.fork

--- a/zio-flow/shared/src/main/scala/zio/flow/ZFlow.scala
+++ b/zio-flow/shared/src/main/scala/zio/flow/ZFlow.scala
@@ -1265,11 +1265,7 @@ object ZFlow {
   /** Creates a flow that waits for the given duration */
   def sleep(duration: Remote[Duration]): ZFlow[Any, ZNothing, Unit] =
     ZFlow.now.flatMap { now =>
-      ZFlow(now.plus(duration)).flatMap { later =>
-        ZFlow.waitTill(later).map { _ =>
-          Remote.unit
-        }
-      }
+      ZFlow.waitTill(now.plus(duration))
     }
 
   /** Creates a flow that returns the given remote value */


### PR DESCRIPTION
Resolves https://github.com/zio/zio-flow/issues/354

- Improved executor logging in order to be able to debug the linked issue
- The linked issue turned out to be not just flaky but it indicated a serious bug in how the executor tracks variable access for transactions. It is now fixed - the core issue was that `RemoteVariableKeyValueStore` was originally designed to a contextual service created in each step, and later it was converted to a single instance per executor; this created shared variable tracking between unrelated flows and also it made restarted transactions to not start from a clean state. I made it contextual once again to fix the execution logic. If this turns out to be a bottleneck we can redesign it (separate the tracking part) later.
- The failing test itself had a bug too, as it was trying to sleep between variable updates to increase the chance that the two concurrent flows are colliding, but it was not using `ZFlow.sleep` but fixed it `waitTill` instants, which are only valid on the first run - retrying the transaction made them no-op (as the instant already passed).