### PR TITLE
Remove Usages Of ZIO.succeedNow

### DIFF
--- a/zio-flow-runtime/src/main/scala/zio/flow/runtime/DurableLog.scala
+++ b/zio-flow-runtime/src/main/scala/zio/flow/runtime/DurableLog.scala
@@ -63,7 +63,7 @@ object DurableLog {
             .mapError(DurableLogError.IndexedStoreError("put", _))
             .flatMap { position =>
               hub.publish(value -> position) *>
-                ZIO.succeedNow(position)
+                ZIO.succeed(position)
             }
         }
       }


### PR DESCRIPTION
This is an internal API and will be deleted.